### PR TITLE
feat(sources): implement Phase 2 multi-source support

### DIFF
--- a/src/cognitive_toolworks/generators/skill.py
+++ b/src/cognitive_toolworks/generators/skill.py
@@ -372,9 +372,42 @@ class SkillGenerator:
 
         return name
 
-    def render_skill(self, skill: SkillContent) -> str:
-        """Render SkillContent to markdown string."""
-        return skill.to_markdown()
+    def render_skill(
+        self, skill: SkillContent, platform: Platform | None = None
+    ) -> str:
+        """
+        Render SkillContent to markdown string using platform-specific template.
+
+        Args:
+            skill: SkillContent to render.
+            platform: Target platform (defaults to config.platform).
+
+        Returns:
+            Rendered markdown string.
+        """
+        platform = platform or self.config.platform
+
+        # Select template based on platform
+        if platform == Platform.OPENAI:
+            template_name = "skill_openai.md.j2"
+        elif platform == Platform.ANTHROPIC:
+            template_name = "skill_anthropic.md.j2"
+        else:  # UNIVERSAL - use Anthropic as it's more restrictive
+            template_name = "skill_anthropic.md.j2"
+
+        template = self._jinja_env.get_template(template_name)
+
+        return template.render(
+            metadata=skill.metadata,
+            overview=skill.overview,
+            when_to_use=skill.when_to_use,
+            quick_reference=skill.quick_reference,
+            instructions=skill.instructions,
+            examples=skill.examples,
+            guidelines=skill.guidelines,
+            troubleshooting=skill.troubleshooting,
+            references=skill.references,
+        )
 
     def save_skill(self, skill: SkillContent, output_dir: Path) -> Path:
         """Save skill to output directory."""

--- a/src/cognitive_toolworks/models.py
+++ b/src/cognitive_toolworks/models.py
@@ -86,7 +86,7 @@ class SkillMetadata:
         return issues
 
     def to_yaml(self) -> str:
-        """Convert to YAML frontmatter string."""
+        """Convert to YAML frontmatter string (Anthropic format)."""
         lines = ["---"]
         lines.append(f"name: {self.name}")
         lines.append(f'description: "{self.description}"')
@@ -98,6 +98,33 @@ class SkillMetadata:
             lines.append("dependencies:")
             for dep in self.dependencies:
                 lines.append(f"  - {dep}")
+
+        if self.license:
+            lines.append(f"license: {self.license}")
+
+        lines.append("---")
+        return "\n".join(lines)
+
+    def to_openai_yaml(self) -> str:
+        """Convert to YAML frontmatter string (OpenAI Codex CLI format)."""
+        lines = ["---"]
+        lines.append(f"name: {self.name}")
+        lines.append(f'description: "{self.description}"')
+
+        # OpenAI format includes category
+        if self.category:
+            lines.append(f"category: {self.category}")
+
+        if self.allowed_tools:
+            lines.append(f"allowed-tools: {', '.join(self.allowed_tools)}")
+
+        if self.dependencies:
+            lines.append("dependencies:")
+            for dep in self.dependencies:
+                lines.append(f"  - {dep}")
+
+        if self.version:
+            lines.append(f"version: {self.version}")
 
         if self.license:
             lines.append(f"license: {self.license}")
@@ -419,4 +446,81 @@ class SemanticAnalysis:
             "error_scenarios": self.error_scenarios,
             "security_considerations": self.security_considerations,
             "recommended_use_cases": self.recommended_use_cases,
+        }
+
+
+@dataclass
+class EndpointDefinition:
+    """Definition of an API endpoint from OpenAPI spec."""
+
+    path: str
+    method: str  # GET, POST, PUT, DELETE, PATCH, etc.
+    summary: str
+    description: str
+    parameters: list[dict[str, Any]] = field(default_factory=list)
+    request_body: dict[str, Any] | None = None
+    responses: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "path": self.path,
+            "method": self.method,
+            "summary": self.summary,
+            "description": self.description,
+            "parameters": self.parameters,
+            "request_body": self.request_body,
+            "responses": self.responses,
+        }
+
+
+@dataclass
+class OpenAPIAnalysis:
+    """Analysis result from OpenAPI specification introspection."""
+
+    api_name: str
+    base_url: str
+    endpoints: list[EndpointDefinition]
+    schemas: dict[str, Any]
+    authentication: dict[str, Any]
+    capabilities: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "api_name": self.api_name,
+            "base_url": self.base_url,
+            "endpoints": [e.to_dict() for e in self.endpoints],
+            "schemas": self.schemas,
+            "authentication": self.authentication,
+            "capabilities": self.capabilities,
+        }
+
+
+@dataclass
+class ReadmeAnalysis:
+    """Analysis result from parsing README/documentation files."""
+
+    project_name: str
+    description: str
+    installation: str | None = None
+    usage_examples: list[dict[str, str]] = field(default_factory=list)
+    features: list[str] = field(default_factory=list)
+    api_reference: str | None = None
+    dependencies: list[str] = field(default_factory=list)
+    badges: list[dict[str, str]] = field(default_factory=list)
+    sections: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "project_name": self.project_name,
+            "description": self.description,
+            "installation": self.installation,
+            "usage_examples": self.usage_examples,
+            "features": self.features,
+            "api_reference": self.api_reference,
+            "dependencies": self.dependencies,
+            "badges": self.badges,
+            "sections": self.sections,
         }

--- a/src/cognitive_toolworks/sources/__init__.py
+++ b/src/cognitive_toolworks/sources/__init__.py
@@ -10,5 +10,14 @@ This module provides adapters for:
 """
 
 from cognitive_toolworks.sources.mcp import MCPIntrospector
+from cognitive_toolworks.sources.openapi import OpenAPIIntrospector
+from cognitive_toolworks.sources.readme import ReadmeParser
+from cognitive_toolworks.sources.scripts import ScriptAnalyzer, analyze_script
 
-__all__ = ["MCPIntrospector"]
+__all__ = [
+    "MCPIntrospector",
+    "OpenAPIIntrospector",
+    "ReadmeParser",
+    "ScriptAnalyzer",
+    "analyze_script",
+]

--- a/src/cognitive_toolworks/sources/openapi.py
+++ b/src/cognitive_toolworks/sources/openapi.py
@@ -1,0 +1,283 @@
+"""
+OpenAPI Specification Introspection Module.
+
+Extracts endpoint definitions, schemas, and capabilities from OpenAPI specs.
+Supports OpenAPI 3.0 and 3.1 in both JSON and YAML formats.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import yaml
+
+from cognitive_toolworks.models import EndpointDefinition, OpenAPIAnalysis
+
+
+class OpenAPIIntrospector:
+    """
+    Introspects OpenAPI specifications to extract API definitions.
+
+    Parses OpenAPI 3.0/3.1 specifications from files or URLs to discover
+    endpoints, schemas, authentication methods, and capabilities.
+    """
+
+    def __init__(self, spec: dict[str, Any]) -> None:
+        """
+        Initialize with a parsed OpenAPI specification.
+
+        Args:
+            spec: Parsed OpenAPI specification dictionary.
+        """
+        self.spec = spec
+        self._validate_spec()
+
+    @classmethod
+    def from_file(cls, path: Path) -> OpenAPIIntrospector:
+        """
+        Load OpenAPI spec from a file.
+
+        Args:
+            path: Path to JSON or YAML file.
+
+        Returns:
+            OpenAPIIntrospector instance.
+
+        Raises:
+            ValueError: If file format is unsupported or invalid.
+        """
+        content = path.read_text()
+
+        # Try to parse based on file extension
+        if path.suffix in (".yaml", ".yml"):
+            spec = yaml.safe_load(content)
+        elif path.suffix == ".json":
+            spec = json.loads(content)
+        else:
+            # Try JSON first, then YAML
+            try:
+                spec = json.loads(content)
+            except json.JSONDecodeError:
+                spec = yaml.safe_load(content)
+
+        return cls(spec)
+
+    @classmethod
+    def from_url(cls, url: str) -> OpenAPIIntrospector:
+        """
+        Load OpenAPI spec from a URL.
+
+        Args:
+            url: URL to OpenAPI specification.
+
+        Returns:
+            OpenAPIIntrospector instance.
+
+        Raises:
+            ValueError: If URL is invalid or cannot be fetched.
+            NotImplementedError: URL loading not yet implemented.
+        """
+        # Parse URL to validate
+        parsed = urlparse(url)
+        if not parsed.scheme or not parsed.netloc:
+            raise ValueError(f"Invalid URL: {url}")
+
+        # TODO: Implement URL fetching with requests
+        raise NotImplementedError("URL loading will be implemented with requests")
+
+    def _validate_spec(self) -> None:
+        """
+        Validate that spec is a valid OpenAPI specification.
+
+        Raises:
+            ValueError: If spec is invalid.
+        """
+        if not isinstance(self.spec, dict):
+            raise ValueError("OpenAPI spec must be a dictionary")
+
+        if "openapi" not in self.spec:
+            raise ValueError("Missing 'openapi' version field")
+
+        version = self.spec["openapi"]
+        if not version.startswith("3."):
+            raise ValueError(f"Only OpenAPI 3.x supported, got {version}")
+
+        if "info" not in self.spec:
+            raise ValueError("Missing 'info' section")
+
+        if "paths" not in self.spec:
+            raise ValueError("Missing 'paths' section")
+
+    def introspect(self) -> OpenAPIAnalysis:
+        """
+        Perform full introspection of the OpenAPI specification.
+
+        Returns:
+            OpenAPIAnalysis containing endpoints, schemas, and capabilities.
+        """
+        return OpenAPIAnalysis(
+            api_name=self._extract_api_name(),
+            base_url=self._extract_base_url(),
+            endpoints=self._extract_endpoints(),
+            schemas=self._extract_schemas(),
+            authentication=self._extract_authentication(),
+            capabilities=self._extract_capabilities(),
+        )
+
+    def _extract_api_name(self) -> str:
+        """Extract API name from spec info."""
+        info = self.spec.get("info", {})
+        title = str(info.get("title", "Unknown API"))
+        version = str(info.get("version", ""))
+        if version:
+            return f"{title} v{version}"
+        return title
+
+    def _extract_base_url(self) -> str:
+        """
+        Extract base URL from servers section.
+
+        Returns first server URL or empty string if none defined.
+        """
+        servers = self.spec.get("servers", [])
+        if servers and len(servers) > 0:
+            return str(servers[0].get("url", ""))
+        return ""
+
+    def _extract_endpoints(self) -> list[EndpointDefinition]:
+        """Extract all endpoint definitions from paths."""
+        endpoints: list[EndpointDefinition] = []
+        paths = self.spec.get("paths", {})
+
+        for path, path_item in paths.items():
+            if not isinstance(path_item, dict):
+                continue
+
+            # Process each HTTP method
+            for method in ["get", "post", "put", "delete", "patch", "options", "head"]:
+                if method in path_item:
+                    operation = path_item[method]
+                    endpoint = self._parse_operation(path, method.upper(), operation)
+                    endpoints.append(endpoint)
+
+        return endpoints
+
+    def _parse_operation(
+        self, path: str, method: str, operation: dict[str, Any]
+    ) -> EndpointDefinition:
+        """
+        Parse a single operation into an EndpointDefinition.
+
+        Args:
+            path: API path (e.g., /users/{id}).
+            method: HTTP method (GET, POST, etc.).
+            operation: Operation object from spec.
+
+        Returns:
+            EndpointDefinition instance.
+        """
+        return EndpointDefinition(
+            path=path,
+            method=method,
+            summary=operation.get("summary", ""),
+            description=operation.get("description", ""),
+            parameters=operation.get("parameters", []),
+            request_body=operation.get("requestBody"),
+            responses=operation.get("responses", {}),
+        )
+
+    def _extract_schemas(self) -> dict[str, Any]:
+        """
+        Extract component schemas from spec.
+
+        Returns:
+            Dictionary of schema definitions.
+        """
+        components = self.spec.get("components", {})
+        schemas = components.get("schemas", {})
+        return dict(schemas) if schemas else {}
+
+    def _extract_authentication(self) -> dict[str, Any]:
+        """
+        Extract authentication/security schemes.
+
+        Returns:
+            Dictionary of security schemes.
+        """
+        components = self.spec.get("components", {})
+        security_schemes = components.get("securitySchemes", {})
+
+        # Also check for global security requirements
+        global_security = self.spec.get("security", [])
+
+        return {
+            "schemes": security_schemes,
+            "global_requirements": global_security,
+        }
+
+    def _extract_capabilities(self) -> list[str]:
+        """
+        Extract API capabilities based on available features.
+
+        Returns:
+            List of capability strings.
+        """
+        capabilities = []
+
+        # Check for different HTTP methods
+        paths = self.spec.get("paths", {})
+        methods_used = set()
+
+        for path_item in paths.values():
+            if not isinstance(path_item, dict):
+                continue
+            for method in ["get", "post", "put", "delete", "patch"]:
+                if method in path_item:
+                    methods_used.add(method.upper())
+
+        if "GET" in methods_used:
+            capabilities.append("read")
+        if any(m in methods_used for m in ["POST", "PUT", "PATCH"]):
+            capabilities.append("write")
+        if "DELETE" in methods_used:
+            capabilities.append("delete")
+
+        # Check for webhooks (OpenAPI 3.1)
+        if "webhooks" in self.spec:
+            capabilities.append("webhooks")
+
+        # Check for authentication
+        auth = self._extract_authentication()
+        if auth.get("schemes") or auth.get("global_requirements"):
+            capabilities.append("authentication")
+
+        # Check for schemas
+        if self._extract_schemas():
+            capabilities.append("schemas")
+
+        return capabilities
+
+
+def introspect_openapi(path_or_url: str) -> OpenAPIAnalysis:
+    """
+    Convenience function to introspect an OpenAPI specification.
+
+    Args:
+        path_or_url: File path or URL to OpenAPI spec.
+
+    Returns:
+        OpenAPIAnalysis with endpoints, schemas, and capabilities.
+
+    Raises:
+        ValueError: If path/URL is invalid or spec cannot be parsed.
+    """
+    # Determine if it's a URL or file path
+    if path_or_url.startswith(("http://", "https://")):
+        introspector = OpenAPIIntrospector.from_url(path_or_url)
+    else:
+        introspector = OpenAPIIntrospector.from_file(Path(path_or_url))
+
+    return introspector.introspect()

--- a/src/cognitive_toolworks/sources/readme.py
+++ b/src/cognitive_toolworks/sources/readme.py
@@ -1,0 +1,413 @@
+"""
+README/Documentation Parser Module.
+
+Extracts structured information from README files and documentation.
+Supports markdown parsing and section extraction.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, ClassVar
+
+from cognitive_toolworks.models import ReadmeAnalysis
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class ReadmeParser:
+    """
+    Parses README and documentation files to extract structured information.
+
+    Analyzes markdown structure, extracts sections, code blocks, badges,
+    and other metadata useful for skill generation.
+    """
+
+    # Common section header patterns (case-insensitive)
+    INSTALLATION_HEADERS: ClassVar[set[str]] = {
+        "installation",
+        "install",
+        "setup",
+        "getting started",
+        "quickstart",
+        "quick start",
+    }
+    USAGE_HEADERS: ClassVar[set[str]] = {
+        "usage",
+        "examples",
+        "example",
+        "getting started",
+        "quickstart",
+    }
+    FEATURES_HEADERS: ClassVar[set[str]] = {
+        "features",
+        "capabilities",
+        "what's included",
+    }
+    API_HEADERS: ClassVar[set[str]] = {
+        "api",
+        "api reference",
+        "reference",
+        "documentation",
+    }
+
+    def __init__(self, content: str) -> None:
+        """
+        Initialize parser with README content.
+
+        Args:
+            content: Raw markdown content of the README file.
+        """
+        self.content = content
+        self.lines = content.split("\n")
+
+    def parse(self) -> ReadmeAnalysis:
+        """
+        Parse the README and extract structured information.
+
+        Returns:
+            ReadmeAnalysis containing extracted sections and metadata.
+        """
+        sections = self._extract_sections()
+        badges = self._extract_badges()
+
+        # Extract key information
+        project_name = self._extract_project_name(sections)
+        description = self._extract_description(sections)
+        installation = self._find_section_content(sections, self.INSTALLATION_HEADERS)
+        usage_examples = self._extract_usage_examples(sections)
+        features = self._extract_features(sections)
+        api_reference = self._find_section_content(sections, self.API_HEADERS)
+        dependencies = self._extract_dependencies(installation or "")
+
+        return ReadmeAnalysis(
+            project_name=project_name,
+            description=description,
+            installation=installation,
+            usage_examples=usage_examples,
+            features=features,
+            api_reference=api_reference,
+            dependencies=dependencies,
+            badges=badges,
+            sections=sections,
+        )
+
+    def _extract_sections(self) -> dict[str, str]:
+        """
+        Extract sections by markdown headers.
+
+        Returns:
+            Dictionary mapping section titles to their content.
+        """
+        sections: dict[str, str] = {}
+        current_section: str | None = None
+        current_content: list[str] = []
+
+        for line in self.lines:
+            # Check if line is a header
+            header_match = re.match(r"^(#{1,6})\s+(.+)$", line)
+
+            if header_match:
+                # Save previous section if exists
+                if current_section:
+                    sections[current_section] = "\n".join(current_content).strip()
+
+                # Start new section
+                level = len(header_match.group(1))
+                title = header_match.group(2).strip()
+
+                # Only track top-level and second-level headers
+                if level <= 2:
+                    current_section = title
+                    current_content = []
+                else:
+                    # Sub-sections are part of current section
+                    if current_section:
+                        current_content.append(line)
+            else:
+                if current_section:
+                    current_content.append(line)
+
+        # Save last section
+        if current_section:
+            sections[current_section] = "\n".join(current_content).strip()
+
+        return sections
+
+    def _extract_badges(self) -> list[dict[str, str]]:
+        """
+        Extract badges from markdown image links.
+
+        Returns:
+            List of badge dictionaries with 'alt', 'url', and 'link' keys.
+        """
+        badges = []
+
+        # Pattern: [![alt](image_url)](link_url)
+        badge_pattern = r"\[!\[([^\]]*)\]\(([^)]+)\)\]\(([^)]+)\)"
+
+        for match in re.finditer(badge_pattern, self.content):
+            badges.append(
+                {
+                    "alt": match.group(1),
+                    "image_url": match.group(2),
+                    "link": match.group(3),
+                }
+            )
+
+        # Also match simple image syntax: ![alt](url)
+        simple_image_pattern = r"!\[([^\]]*)\]\(([^)]+)\)"
+
+        for match in re.finditer(simple_image_pattern, self.content):
+            # Avoid duplicates from badge pattern
+            alt = match.group(1)
+            url = match.group(2)
+
+            # Check if this looks like a badge (shields.io, badge URLs, etc.)
+            if any(
+                badge_host in url
+                for badge_host in ["shields.io", "badge", "img.shields.io"]
+            ):
+                # Check if not already added
+                if not any(b.get("image_url") == url for b in badges):
+                    badges.append({"alt": alt, "image_url": url, "link": ""})
+
+        return badges
+
+    def _extract_code_blocks(self) -> list[dict[str, str]]:
+        """
+        Extract code blocks with their language and content.
+
+        Returns:
+            List of dictionaries with 'language' and 'content' keys.
+        """
+        code_blocks = []
+        in_code_block = False
+        current_language = ""
+        current_content: list[str] = []
+
+        for line in self.lines:
+            # Check for code block start
+            if line.startswith("```"):
+                if not in_code_block:
+                    # Starting a code block
+                    in_code_block = True
+                    current_language = line[3:].strip() or "text"
+                    current_content = []
+                else:
+                    # Ending a code block
+                    in_code_block = False
+                    code_blocks.append(
+                        {
+                            "language": current_language,
+                            "content": "\n".join(current_content),
+                        }
+                    )
+            elif in_code_block:
+                current_content.append(line)
+
+        return code_blocks
+
+    def _extract_project_name(self, sections: dict[str, str]) -> str:
+        """
+        Extract project name from the first header or document title.
+
+        Args:
+            sections: Extracted sections dictionary.
+
+        Returns:
+            Project name string.
+        """
+        # Try first header
+        for line in self.lines:
+            if line.startswith("# "):
+                return line[2:].strip()
+
+        # Fallback to first section title
+        if sections:
+            return next(iter(sections.keys()))
+
+        return "Unknown Project"
+
+    def _extract_description(self, sections: dict[str, str]) -> str:
+        """
+        Extract project description.
+
+        Args:
+            sections: Extracted sections dictionary.
+
+        Returns:
+            Project description string.
+        """
+        # Look for content after the first header but before second section
+        first_section_key = next(iter(sections.keys())) if sections else None
+
+        if first_section_key:
+            content = sections[first_section_key]
+
+            # Extract first paragraph
+            paragraphs = [p.strip() for p in content.split("\n\n") if p.strip()]
+
+            if paragraphs:
+                # Filter out badge lines and get first real paragraph
+                for para in paragraphs:
+                    if not para.startswith("![") and not para.startswith("[!["):
+                        return para
+
+        return ""
+
+    def _find_section_content(
+        self,
+        sections: dict[str, str],
+        header_keywords: set[str],
+    ) -> str | None:
+        """
+        Find section content by matching header keywords.
+
+        Args:
+            sections: Extracted sections dictionary.
+            header_keywords: Set of keywords to match against section titles.
+
+        Returns:
+            Section content if found, None otherwise.
+        """
+        for title, content in sections.items():
+            title_lower = title.lower()
+            if any(keyword in title_lower for keyword in header_keywords):
+                return content
+
+        return None
+
+    def _extract_usage_examples(self, sections: dict[str, str]) -> list[dict[str, str]]:
+        """
+        Extract usage examples from usage/examples sections.
+
+        Args:
+            sections: Extracted sections dictionary.
+
+        Returns:
+            List of usage example dictionaries.
+        """
+        examples = []
+
+        # Find usage/examples section
+        usage_content = self._find_section_content(sections, self.USAGE_HEADERS)
+
+        if usage_content:
+            # Extract code blocks from usage section
+            in_code_block = False
+            current_language = ""
+            current_content: list[str] = []
+            description = ""
+
+            for line in usage_content.split("\n"):
+                if line.startswith("```"):
+                    if not in_code_block:
+                        in_code_block = True
+                        current_language = line[3:].strip() or "text"
+                        current_content = []
+                    else:
+                        in_code_block = False
+                        examples.append(
+                            {
+                                "language": current_language,
+                                "code": "\n".join(current_content),
+                                "description": description.strip(),
+                            }
+                        )
+                        description = ""
+                elif in_code_block:
+                    current_content.append(line)
+                else:
+                    # Capture description before code block
+                    if line.strip():
+                        description += line + " "
+
+        return examples
+
+    def _extract_features(self, sections: dict[str, str]) -> list[str]:
+        """
+        Extract feature list from features section.
+
+        Args:
+            sections: Extracted sections dictionary.
+
+        Returns:
+            List of feature strings.
+        """
+        features = []
+
+        # Find features section
+        features_content = self._find_section_content(sections, self.FEATURES_HEADERS)
+
+        if features_content:
+            # Extract bullet points
+            for line in features_content.split("\n"):
+                line = line.strip()
+                # Match markdown list items (-, *, +)
+                if re.match(r"^[-*+]\s+", line):
+                    feature = re.sub(r"^[-*+]\s+", "", line).strip()
+                    features.append(feature)
+
+        return features
+
+    def _extract_dependencies(self, installation_content: str) -> list[str]:
+        """
+        Extract dependencies from installation instructions.
+
+        Args:
+            installation_content: Content of installation section.
+
+        Returns:
+            List of dependency strings.
+        """
+        dependencies: list[str] = []
+
+        if not installation_content:
+            return dependencies
+
+        # Look for common package manager commands
+        patterns = [
+            r"pip install\s+([^\n]+)",
+            r"npm install\s+([^\n]+)",
+            r"yarn add\s+([^\n]+)",
+            r"gem install\s+([^\n]+)",
+            r"go get\s+([^\n]+)",
+        ]
+
+        for pattern in patterns:
+            matches = re.finditer(pattern, installation_content)
+            for match in matches:
+                # Parse package names
+                packages = match.group(1).strip()
+
+                # Split into tokens
+                tokens = packages.split()
+
+                # Filter out flags and options (anything starting with -)
+                for token in tokens:
+                    token = token.strip()
+                    # Skip flags
+                    if token.startswith("-"):
+                        continue
+                    # Add valid package names
+                    if token and token not in dependencies:
+                        dependencies.append(token)
+
+        return dependencies
+
+
+def parse_readme(path: Path) -> ReadmeAnalysis:
+    """
+    Convenience function to parse a README file.
+
+    Args:
+        path: Path to README file.
+
+    Returns:
+        ReadmeAnalysis with extracted information.
+    """
+    content = path.read_text(encoding="utf-8")
+    parser = ReadmeParser(content)
+    return parser.parse()

--- a/src/cognitive_toolworks/sources/scripts.py
+++ b/src/cognitive_toolworks/sources/scripts.py
@@ -1,0 +1,559 @@
+"""
+Script Analysis Module.
+
+Analyzes Python, TypeScript/JavaScript, and Bash scripts to extract
+capabilities, functions, and usage patterns for skill generation.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class ScriptLanguage(str, Enum):
+    """Supported script languages."""
+
+    PYTHON = "python"
+    TYPESCRIPT = "typescript"
+    JAVASCRIPT = "javascript"
+    BASH = "bash"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def from_extension(cls, ext: str) -> ScriptLanguage:
+        """Determine language from file extension."""
+        mapping = {
+            ".py": cls.PYTHON,
+            ".ts": cls.TYPESCRIPT,
+            ".tsx": cls.TYPESCRIPT,
+            ".js": cls.JAVASCRIPT,
+            ".jsx": cls.JAVASCRIPT,
+            ".mjs": cls.JAVASCRIPT,
+            ".sh": cls.BASH,
+            ".bash": cls.BASH,
+        }
+        return mapping.get(ext.lower(), cls.UNKNOWN)
+
+
+@dataclass
+class FunctionInfo:
+    """Information about a function/method in a script."""
+
+    name: str
+    description: str
+    parameters: list[dict[str, Any]]
+    return_type: str | None
+    is_async: bool
+    is_exported: bool
+    line_number: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "parameters": self.parameters,
+            "return_type": self.return_type,
+            "is_async": self.is_async,
+            "is_exported": self.is_exported,
+            "line_number": self.line_number,
+        }
+
+
+@dataclass
+class ClassInfo:
+    """Information about a class in a script."""
+
+    name: str
+    description: str
+    methods: list[FunctionInfo]
+    base_classes: list[str]
+    line_number: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "methods": [m.to_dict() for m in self.methods],
+            "base_classes": self.base_classes,
+            "line_number": self.line_number,
+        }
+
+
+@dataclass
+class ScriptAnalysis:
+    """Analysis result from script parsing."""
+
+    file_path: str
+    language: ScriptLanguage
+    description: str
+    functions: list[FunctionInfo] = field(default_factory=list)
+    classes: list[ClassInfo] = field(default_factory=list)
+    imports: list[str] = field(default_factory=list)
+    exports: list[str] = field(default_factory=list)
+    cli_commands: list[dict[str, Any]] = field(default_factory=list)
+    env_vars: list[str] = field(default_factory=list)
+    dependencies: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "file_path": self.file_path,
+            "language": self.language.value,
+            "description": self.description,
+            "functions": [f.to_dict() for f in self.functions],
+            "classes": [c.to_dict() for c in self.classes],
+            "imports": self.imports,
+            "exports": self.exports,
+            "cli_commands": self.cli_commands,
+            "env_vars": self.env_vars,
+            "dependencies": self.dependencies,
+        }
+
+
+class ScriptAnalyzer:
+    """
+    Analyzes scripts to extract capabilities and structure.
+
+    Supports Python, TypeScript/JavaScript, and Bash scripts.
+    """
+
+    def analyze(self, path: Path) -> ScriptAnalysis:
+        """
+        Analyze a script file.
+
+        Args:
+            path: Path to the script file.
+
+        Returns:
+            ScriptAnalysis with extracted information.
+        """
+        content = path.read_text(encoding="utf-8")
+        language = ScriptLanguage.from_extension(path.suffix)
+
+        if language == ScriptLanguage.PYTHON:
+            return self._analyze_python(path, content)
+        elif language in (ScriptLanguage.TYPESCRIPT, ScriptLanguage.JAVASCRIPT):
+            return self._analyze_js_ts(path, content, language)
+        elif language == ScriptLanguage.BASH:
+            return self._analyze_bash(path, content)
+        else:
+            return ScriptAnalysis(
+                file_path=str(path),
+                language=language,
+                description="Unknown script type",
+            )
+
+    def _analyze_python(self, path: Path, content: str) -> ScriptAnalysis:
+        """Analyze a Python script."""
+        try:
+            tree = ast.parse(content)
+        except SyntaxError:
+            return ScriptAnalysis(
+                file_path=str(path),
+                language=ScriptLanguage.PYTHON,
+                description="Failed to parse Python file",
+            )
+
+        # Extract module docstring
+        description = ast.get_docstring(tree) or ""
+
+        # Extract functions
+        functions = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                func_info = self._extract_python_function(node)
+                if not func_info.name.startswith("_") or func_info.name.startswith(
+                    "__"
+                ):
+                    functions.append(func_info)
+
+        # Extract classes
+        classes = []
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, ast.ClassDef):
+                class_info = self._extract_python_class(node)
+                classes.append(class_info)
+
+        # Extract imports
+        imports = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imports.append(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    imports.append(node.module)
+
+        # Extract environment variables
+        env_vars = self._extract_env_vars(content)
+
+        # Extract CLI commands (argparse, click, typer patterns)
+        cli_commands = self._extract_python_cli(tree, content)
+
+        return ScriptAnalysis(
+            file_path=str(path),
+            language=ScriptLanguage.PYTHON,
+            description=description[:500] if description else "",
+            functions=functions,
+            classes=classes,
+            imports=imports,
+            env_vars=env_vars,
+            cli_commands=cli_commands,
+            dependencies=self._extract_python_deps(imports),
+        )
+
+    def _extract_python_function(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> FunctionInfo:
+        """Extract function information from AST node."""
+        docstring = ast.get_docstring(node) or ""
+
+        # Extract parameters
+        params = []
+        for arg in node.args.args:
+            param = {"name": arg.arg}
+            if arg.annotation:
+                param["type"] = ast.unparse(arg.annotation)
+            params.append(param)
+
+        # Extract return type
+        return_type = None
+        if node.returns:
+            return_type = ast.unparse(node.returns)
+
+        return FunctionInfo(
+            name=node.name,
+            description=docstring[:200] if docstring else "",
+            parameters=params,
+            return_type=return_type,
+            is_async=isinstance(node, ast.AsyncFunctionDef),
+            is_exported=not node.name.startswith("_"),
+            line_number=node.lineno,
+        )
+
+    def _extract_python_class(self, node: ast.ClassDef) -> ClassInfo:
+        """Extract class information from AST node."""
+        docstring = ast.get_docstring(node) or ""
+
+        # Extract base classes
+        bases = []
+        for base in node.bases:
+            with contextlib.suppress(ValueError, AttributeError):
+                bases.append(ast.unparse(base))
+
+        # Extract methods
+        methods = []
+        for item in node.body:
+            if isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef):
+                if not item.name.startswith("_") or item.name in (
+                    "__init__",
+                    "__call__",
+                ):
+                    methods.append(self._extract_python_function(item))
+
+        return ClassInfo(
+            name=node.name,
+            description=docstring[:200] if docstring else "",
+            methods=methods,
+            base_classes=bases,
+            line_number=node.lineno,
+        )
+
+    def _extract_python_cli(
+        self, _tree: ast.Module, content: str
+    ) -> list[dict[str, Any]]:
+        """Extract CLI command definitions."""
+        commands = []
+
+        # Check for typer patterns
+        if "typer" in content.lower():
+            # Look for @app.command() decorators
+            for match in re.finditer(r'@\w+\.command\(["\']?(\w+)?["\']?\)', content):
+                cmd_name = match.group(1) or "default"
+                commands.append({"name": cmd_name, "framework": "typer"})
+
+        # Check for click patterns
+        if "click" in content.lower():
+            for match in re.finditer(r'@click\.command\(["\']?(\w+)?["\']?\)', content):
+                cmd_name = match.group(1) or "default"
+                commands.append({"name": cmd_name, "framework": "click"})
+
+        # Check for argparse patterns
+        if "argparse" in content.lower():
+            for match in re.finditer(r'add_subparsers|add_parser\(["\'](\w+)', content):
+                if match.group(1):
+                    commands.append({"name": match.group(1), "framework": "argparse"})
+
+        return commands
+
+    def _extract_python_deps(self, imports: list[str]) -> list[str]:
+        """Extract third-party dependencies from imports."""
+        stdlib = {
+            "os",
+            "sys",
+            "re",
+            "json",
+            "pathlib",
+            "typing",
+            "dataclasses",
+            "enum",
+            "abc",
+            "collections",
+            "itertools",
+            "functools",
+            "contextlib",
+            "asyncio",
+            "subprocess",
+            "io",
+            "datetime",
+            "time",
+            "math",
+            "random",
+            "copy",
+            "pickle",
+            "hashlib",
+            "base64",
+            "urllib",
+            "http",
+            "logging",
+            "unittest",
+            "tempfile",
+            "shutil",
+            "glob",
+            "fnmatch",
+            "stat",
+            "argparse",
+            "configparser",
+            "csv",
+            "xml",
+            "html",
+            "socket",
+            "ssl",
+            "threading",
+            "multiprocessing",
+            "queue",
+            "concurrent",
+            "ast",
+            "inspect",
+            "traceback",
+            "warnings",
+            "textwrap",
+            "string",
+            "struct",
+            "codecs",
+            "locale",
+            "gettext",
+            "secrets",
+            "uuid",
+            "pprint",
+        }
+
+        deps = []
+        for imp in imports:
+            # Get the top-level package name
+            top_level = imp.split(".")[0]
+            if top_level not in stdlib and top_level not in deps:
+                deps.append(top_level)
+
+        return deps
+
+    def _analyze_js_ts(
+        self, path: Path, content: str, language: ScriptLanguage
+    ) -> ScriptAnalysis:
+        """Analyze a JavaScript/TypeScript file using regex patterns."""
+        description = ""
+
+        # Extract file-level JSDoc comment
+        jsdoc_match = re.match(r"/\*\*\s*\n(.*?)\*/", content, re.DOTALL)
+        if jsdoc_match:
+            description = re.sub(r"\s*\*\s*", " ", jsdoc_match.group(1)).strip()
+
+        # Extract functions
+        functions = []
+        # Match: function name(...) or const name = (...) => or async function
+        func_patterns = [
+            r"(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)",
+            r"(?:export\s+)?const\s+(\w+)\s*=\s*(?:async\s+)?\([^)]*\)\s*=>",
+            r"(?:export\s+)?const\s+(\w+)\s*=\s*(?:async\s+)?function",
+        ]
+
+        for pattern in func_patterns:
+            for match in re.finditer(pattern, content):
+                name = match.group(1)
+                is_exported = "export" in match.group(0)
+                is_async = "async" in match.group(0)
+
+                # Get line number
+                line_num = content[: match.start()].count("\n") + 1
+
+                functions.append(
+                    FunctionInfo(
+                        name=name,
+                        description="",
+                        parameters=[],
+                        return_type=None,
+                        is_async=is_async,
+                        is_exported=is_exported,
+                        line_number=line_num,
+                    )
+                )
+
+        # Extract classes
+        classes = []
+        class_pattern = r"(?:export\s+)?class\s+(\w+)(?:\s+extends\s+(\w+))?"
+        for match in re.finditer(class_pattern, content):
+            name = match.group(1)
+            base = match.group(2)
+            line_num = content[: match.start()].count("\n") + 1
+
+            classes.append(
+                ClassInfo(
+                    name=name,
+                    description="",
+                    methods=[],
+                    base_classes=[base] if base else [],
+                    line_number=line_num,
+                )
+            )
+
+        # Extract imports
+        imports = []
+        import_patterns = [
+            r'import\s+.*?from\s+["\']([^"\']+)["\']',
+            r'require\(["\']([^"\']+)["\']\)',
+        ]
+        for pattern in import_patterns:
+            for match in re.finditer(pattern, content):
+                imports.append(match.group(1))
+
+        # Extract exports
+        exports = []
+        export_pattern = (
+            r"export\s+(?:const|let|var|function|class|async\s+function)\s+(\w+)"
+        )
+        for match in re.finditer(export_pattern, content):
+            exports.append(match.group(1))
+
+        # Extract environment variables
+        env_vars = self._extract_env_vars(content)
+
+        return ScriptAnalysis(
+            file_path=str(path),
+            language=language,
+            description=description[:500],
+            functions=functions,
+            classes=classes,
+            imports=imports,
+            exports=exports,
+            env_vars=env_vars,
+        )
+
+    def _analyze_bash(self, path: Path, content: str) -> ScriptAnalysis:
+        """Analyze a Bash script."""
+        description = ""
+
+        # Extract script description from header comments
+        lines = content.split("\n")
+        desc_lines = []
+        for line in lines[1:20]:  # Skip shebang, check first 20 lines
+            if line.startswith("#") and not line.startswith("#!"):
+                desc_lines.append(line[1:].strip())
+            elif line.strip() and not line.startswith("#"):
+                break
+        description = " ".join(desc_lines)
+
+        # Extract functions
+        functions = []
+        func_pattern = r"(?:function\s+)?(\w+)\s*\(\s*\)\s*\{"
+        for match in re.finditer(func_pattern, content):
+            name = match.group(1)
+            if name not in ("if", "while", "for", "case"):
+                line_num = content[: match.start()].count("\n") + 1
+                functions.append(
+                    FunctionInfo(
+                        name=name,
+                        description="",
+                        parameters=[],
+                        return_type=None,
+                        is_async=False,
+                        is_exported=True,
+                        line_number=line_num,
+                    )
+                )
+
+        # Extract environment variables
+        env_vars = self._extract_env_vars(content)
+
+        # Extract CLI commands (subcommands from case statements)
+        cli_commands = []
+        case_pattern = r'case\s+["\']?\$\{?1\}?["\']?\s+in(.*?)esac'
+        case_match = re.search(case_pattern, content, re.DOTALL)
+        if case_match:
+            case_content = case_match.group(1)
+            cmd_pattern = r"([a-z_-]+)\)"
+            for cmd_match in re.finditer(cmd_pattern, case_content):
+                cmd = cmd_match.group(1)
+                if cmd not in ("*", "-*", "--*"):
+                    cli_commands.append({"name": cmd, "framework": "bash"})
+
+        return ScriptAnalysis(
+            file_path=str(path),
+            language=ScriptLanguage.BASH,
+            description=description[:500],
+            functions=functions,
+            cli_commands=cli_commands,
+            env_vars=env_vars,
+        )
+
+    def _extract_env_vars(self, content: str) -> list[str]:
+        """Extract environment variable references."""
+        env_vars = set()
+
+        # Python: os.environ, os.getenv
+        patterns = [
+            r'os\.environ(?:\.get)?\(["\'](\w+)["\']',
+            r'os\.getenv\(["\'](\w+)["\']',
+            r'environ\[["\'](\w+)["\']',
+            # JavaScript: process.env
+            r"process\.env\.(\w+)",
+            r'process\.env\[["\'](\w+)["\']',
+            # Bash: $VAR, ${VAR}
+            r"\$\{?([A-Z][A-Z0-9_]*)\}?",
+        ]
+
+        for pattern in patterns:
+            for match in re.finditer(pattern, content):
+                env_vars.add(match.group(1))
+
+        # Filter out common non-env vars
+        filtered = {
+            v
+            for v in env_vars
+            if v not in ("PATH", "HOME", "USER", "PWD", "SHELL") and len(v) > 2
+        }
+
+        return sorted(filtered)
+
+
+def analyze_script(path: Path) -> ScriptAnalysis:
+    """
+    Convenience function to analyze a script file.
+
+    Args:
+        path: Path to the script file.
+
+    Returns:
+        ScriptAnalysis with extracted information.
+    """
+    analyzer = ScriptAnalyzer()
+    return analyzer.analyze(path)

--- a/src/cognitive_toolworks/templates/skill_openai.md.j2
+++ b/src/cognitive_toolworks/templates/skill_openai.md.j2
@@ -1,0 +1,84 @@
+---
+name: {{ metadata.name }}
+description: "{{ metadata.description }}"
+{% if metadata.category -%}
+category: {{ metadata.category }}
+{% endif -%}
+{% if metadata.allowed_tools -%}
+allowed-tools: {{ metadata.allowed_tools | join(', ') }}
+{% endif -%}
+{% if metadata.dependencies -%}
+dependencies:
+{% for dep in metadata.dependencies %}
+  - {{ dep }}
+{% endfor %}
+{% endif -%}
+{% if metadata.version -%}
+version: {{ metadata.version }}
+{% endif -%}
+{% if metadata.license -%}
+license: {{ metadata.license }}
+{% endif -%}
+---
+
+# {{ metadata.name | replace('-', ' ') | title }}
+
+{{ overview }}
+
+## When to Use This Skill
+
+{% for item in when_to_use -%}
+- {{ item }}
+{% endfor %}
+
+## Quick Reference
+
+{{ quick_reference }}
+
+## Instructions
+
+{{ instructions }}
+
+{% if examples %}
+## Examples
+
+{% for example in examples %}
+### Example {{ loop.index }}: {{ example.title | default('Example') }}
+
+{{ example.description | default('') }}
+
+{% if example.code %}
+```{{ example.language | default('bash') }}
+{{ example.code }}
+```
+{% endif %}
+
+{% endfor %}
+{% endif %}
+
+{% if guidelines %}
+## Guidelines
+
+{% for guideline in guidelines -%}
+- {{ guideline }}
+{% endfor %}
+{% endif %}
+
+{% if troubleshooting %}
+## Troubleshooting
+
+{% for item in troubleshooting %}
+### {{ item.issue | default('Issue') }}
+
+{{ item.solution | default('') }}
+
+{% endfor %}
+{% endif %}
+
+{% if references %}
+## See Also
+
+{% for ref in references -%}
+- {{ ref }}
+{% endfor %}
+{% endif %}

--- a/tests/fixtures/openapi/sample_api.yaml
+++ b/tests/fixtures/openapi/sample_api.yaml
@@ -1,0 +1,104 @@
+openapi: "3.0.0"
+info:
+  title: Sample API
+  version: "1.0"
+  description: A sample API for testing OpenAPI introspection
+servers:
+  - url: https://api.example.com/v1
+paths:
+  /users:
+    get:
+      summary: List users
+      description: Retrieve a list of all users
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of users to return
+          schema:
+            type: integer
+            default: 10
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+    post:
+      summary: Create user
+      description: Create a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  /users/{id}:
+    get:
+      summary: Get user by ID
+      description: Retrieve a specific user by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: User ID
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '404':
+          description: User not found
+    delete:
+      summary: Delete user
+      description: Delete a user by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: User ID
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: No content
+        '404':
+          description: User not found
+components:
+  schemas:
+    User:
+      type: object
+      required:
+        - name
+        - email
+      properties:
+        id:
+          type: integer
+          description: User ID
+        name:
+          type: string
+          description: User's full name
+        email:
+          type: string
+          format: email
+          description: User's email address
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+security:
+  - ApiKeyAuth: []

--- a/tests/unit/test_sources_openapi.py
+++ b/tests/unit/test_sources_openapi.py
@@ -1,0 +1,412 @@
+"""Tests for OpenAPI introspection module."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cognitive_toolworks.sources.openapi import (
+    OpenAPIIntrospector,
+    introspect_openapi,
+)
+
+
+class TestOpenAPIIntrospector:
+    """Tests for OpenAPIIntrospector class."""
+
+    @pytest.fixture
+    def sample_spec(self) -> dict:
+        """Create a minimal OpenAPI spec for testing."""
+        return {
+            "openapi": "3.0.0",
+            "info": {"title": "Test API", "version": "1.0"},
+            "paths": {
+                "/users": {
+                    "get": {
+                        "summary": "List users",
+                        "description": "Get all users",
+                        "responses": {"200": {"description": "Success"}},
+                    }
+                }
+            },
+        }
+
+    def test_from_dict(self, sample_spec: dict) -> None:
+        """Test creating introspector from dictionary."""
+        introspector = OpenAPIIntrospector(sample_spec)
+        assert introspector.spec == sample_spec
+
+    def test_validate_spec_missing_openapi(self) -> None:
+        """Test validation fails when openapi field is missing."""
+        with pytest.raises(ValueError, match="Missing 'openapi' version field"):
+            OpenAPIIntrospector({"info": {"title": "Test"}})
+
+    def test_validate_spec_unsupported_version(self) -> None:
+        """Test validation fails for unsupported OpenAPI versions."""
+        with pytest.raises(ValueError, match="Only OpenAPI 3.x supported"):
+            OpenAPIIntrospector({"openapi": "2.0", "info": {}, "paths": {}})
+
+    def test_validate_spec_missing_info(self) -> None:
+        """Test validation fails when info section is missing."""
+        with pytest.raises(ValueError, match="Missing 'info' section"):
+            OpenAPIIntrospector({"openapi": "3.0.0", "paths": {}})
+
+    def test_validate_spec_missing_paths(self) -> None:
+        """Test validation fails when paths section is missing."""
+        with pytest.raises(ValueError, match="Missing 'paths' section"):
+            OpenAPIIntrospector({"openapi": "3.0.0", "info": {"title": "Test"}})
+
+    def test_extract_api_name_with_version(self, sample_spec: dict) -> None:
+        """Test extracting API name with version."""
+        introspector = OpenAPIIntrospector(sample_spec)
+        assert introspector._extract_api_name() == "Test API v1.0"
+
+    def test_extract_api_name_without_version(self) -> None:
+        """Test extracting API name without version."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "No Version API"},
+            "paths": {},
+        }
+        introspector = OpenAPIIntrospector(spec)
+        assert introspector._extract_api_name() == "No Version API"
+
+    def test_extract_base_url(self) -> None:
+        """Test extracting base URL from servers."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Test"},
+            "servers": [{"url": "https://api.example.com/v1"}],
+            "paths": {},
+        }
+        introspector = OpenAPIIntrospector(spec)
+        assert introspector._extract_base_url() == "https://api.example.com/v1"
+
+    def test_extract_base_url_no_servers(self, sample_spec: dict) -> None:
+        """Test extracting base URL when no servers defined."""
+        introspector = OpenAPIIntrospector(sample_spec)
+        assert introspector._extract_base_url() == ""
+
+    def test_extract_endpoints(self, sample_spec: dict) -> None:
+        """Test extracting endpoint definitions."""
+        introspector = OpenAPIIntrospector(sample_spec)
+        endpoints = introspector._extract_endpoints()
+
+        assert len(endpoints) == 1
+        endpoint = endpoints[0]
+        assert endpoint.path == "/users"
+        assert endpoint.method == "GET"
+        assert endpoint.summary == "List users"
+        assert endpoint.description == "Get all users"
+
+    def test_extract_multiple_methods(self) -> None:
+        """Test extracting multiple HTTP methods for same path."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Test"},
+            "paths": {
+                "/users": {
+                    "get": {"summary": "List users", "responses": {}},
+                    "post": {"summary": "Create user", "responses": {}},
+                }
+            },
+        }
+        introspector = OpenAPIIntrospector(spec)
+        endpoints = introspector._extract_endpoints()
+
+        assert len(endpoints) == 2
+        methods = {e.method for e in endpoints}
+        assert methods == {"GET", "POST"}
+
+    def test_extract_parameters(self) -> None:
+        """Test extracting endpoint parameters."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Test"},
+            "paths": {
+                "/users": {
+                    "get": {
+                        "summary": "List users",
+                        "parameters": [
+                            {
+                                "name": "limit",
+                                "in": "query",
+                                "schema": {"type": "integer"},
+                            }
+                        ],
+                        "responses": {},
+                    }
+                }
+            },
+        }
+        introspector = OpenAPIIntrospector(spec)
+        endpoints = introspector._extract_endpoints()
+
+        assert len(endpoints[0].parameters) == 1
+        assert endpoints[0].parameters[0]["name"] == "limit"
+        assert endpoints[0].parameters[0]["in"] == "query"
+
+    def test_extract_request_body(self) -> None:
+        """Test extracting request body definition."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Test"},
+            "paths": {
+                "/users": {
+                    "post": {
+                        "summary": "Create user",
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "application/json": {"schema": {"type": "object"}}
+                            },
+                        },
+                        "responses": {},
+                    }
+                }
+            },
+        }
+        introspector = OpenAPIIntrospector(spec)
+        endpoints = introspector._extract_endpoints()
+
+        assert endpoints[0].request_body is not None
+        assert endpoints[0].request_body["required"] is True
+
+    def test_extract_schemas(self) -> None:
+        """Test extracting component schemas."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Test"},
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "User": {
+                        "type": "object",
+                        "properties": {"id": {"type": "integer"}},
+                    }
+                }
+            },
+        }
+        introspector = OpenAPIIntrospector(spec)
+        schemas = introspector._extract_schemas()
+
+        assert "User" in schemas
+        assert schemas["User"]["type"] == "object"
+
+    def test_extract_schemas_no_components(self, sample_spec: dict) -> None:
+        """Test extracting schemas when components section is missing."""
+        introspector = OpenAPIIntrospector(sample_spec)
+        schemas = introspector._extract_schemas()
+        assert schemas == {}
+
+    def test_extract_authentication(self) -> None:
+        """Test extracting authentication schemes."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Test"},
+            "paths": {},
+            "components": {
+                "securitySchemes": {
+                    "ApiKeyAuth": {
+                        "type": "apiKey",
+                        "in": "header",
+                        "name": "X-API-Key",
+                    }
+                }
+            },
+            "security": [{"ApiKeyAuth": []}],
+        }
+        introspector = OpenAPIIntrospector(spec)
+        auth = introspector._extract_authentication()
+
+        assert "ApiKeyAuth" in auth["schemes"]
+        assert auth["schemes"]["ApiKeyAuth"]["type"] == "apiKey"
+        assert len(auth["global_requirements"]) == 1
+
+    def test_extract_capabilities(self) -> None:
+        """Test extracting API capabilities."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Test"},
+            "paths": {
+                "/users": {
+                    "get": {"summary": "List", "responses": {}},
+                    "post": {"summary": "Create", "responses": {}},
+                    "delete": {"summary": "Delete", "responses": {}},
+                }
+            },
+            "components": {
+                "schemas": {"User": {"type": "object"}},
+                "securitySchemes": {"ApiKey": {"type": "apiKey"}},
+            },
+        }
+        introspector = OpenAPIIntrospector(spec)
+        capabilities = introspector._extract_capabilities()
+
+        assert "read" in capabilities  # GET
+        assert "write" in capabilities  # POST
+        assert "delete" in capabilities  # DELETE
+        assert "schemas" in capabilities
+        assert "authentication" in capabilities
+
+    def test_introspect_full_analysis(self, sample_spec: dict) -> None:
+        """Test full introspection returns OpenAPIAnalysis."""
+        introspector = OpenAPIIntrospector(sample_spec)
+        analysis = introspector.introspect()
+
+        assert analysis.api_name == "Test API v1.0"
+        assert len(analysis.endpoints) == 1
+        assert isinstance(analysis.schemas, dict)
+        assert isinstance(analysis.authentication, dict)
+        assert isinstance(analysis.capabilities, list)
+
+    def test_from_file_yaml(self) -> None:
+        """Test loading from YAML file."""
+        spec_path = (
+            Path(__file__).parent.parent / "fixtures" / "openapi" / "sample_api.yaml"
+        )
+        introspector = OpenAPIIntrospector.from_file(spec_path)
+
+        assert introspector.spec["info"]["title"] == "Sample API"
+        analysis = introspector.introspect()
+        assert len(analysis.endpoints) > 0
+
+    def test_from_file_json(self) -> None:
+        """Test loading from JSON file."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "JSON Test"},
+            "paths": {},
+        }
+
+        with tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False) as f:
+            json.dump(spec, f)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            introspector = OpenAPIIntrospector.from_file(path)
+            assert introspector.spec["info"]["title"] == "JSON Test"
+        finally:
+            path.unlink()
+
+    def test_from_file_no_extension_json(self) -> None:
+        """Test loading from file with no extension (JSON content)."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "No Ext"},
+            "paths": {},
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            json.dump(spec, f)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            introspector = OpenAPIIntrospector.from_file(path)
+            assert introspector.spec["info"]["title"] == "No Ext"
+        finally:
+            path.unlink()
+
+    def test_from_url_raises_not_implemented(self) -> None:
+        """Test that URL loading raises NotImplementedError."""
+        with pytest.raises(NotImplementedError):
+            OpenAPIIntrospector.from_url("https://example.com/openapi.json")
+
+    def test_from_url_invalid_url(self) -> None:
+        """Test that invalid URLs raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid URL"):
+            OpenAPIIntrospector.from_url("not-a-url")
+
+
+class TestIntrospectOpenAPI:
+    """Tests for introspect_openapi convenience function."""
+
+    def test_introspect_from_file(self) -> None:
+        """Test introspecting from file path."""
+        spec_path = (
+            Path(__file__).parent.parent / "fixtures" / "openapi" / "sample_api.yaml"
+        )
+        analysis = introspect_openapi(str(spec_path))
+
+        assert analysis.api_name == "Sample API v1.0"
+        assert analysis.base_url == "https://api.example.com/v1"
+        assert (
+            len(analysis.endpoints) == 4
+        )  # GET /users, POST /users, GET /users/{id}, DELETE /users/{id}
+
+        # Check endpoints
+        paths = {e.path for e in analysis.endpoints}
+        assert "/users" in paths
+        assert "/users/{id}" in paths
+
+        # Check methods
+        methods = {(e.path, e.method) for e in analysis.endpoints}
+        assert ("/users", "GET") in methods
+        assert ("/users", "POST") in methods
+        assert ("/users/{id}", "GET") in methods
+        assert ("/users/{id}", "DELETE") in methods
+
+        # Check schemas
+        assert "User" in analysis.schemas
+        assert analysis.schemas["User"]["type"] == "object"
+
+        # Check authentication
+        assert "ApiKeyAuth" in analysis.authentication["schemes"]
+        assert len(analysis.authentication["global_requirements"]) == 1
+
+        # Check capabilities
+        assert "read" in analysis.capabilities
+        assert "write" in analysis.capabilities
+        assert "delete" in analysis.capabilities
+        assert "schemas" in analysis.capabilities
+        assert "authentication" in analysis.capabilities
+
+    def test_introspect_url_not_implemented(self) -> None:
+        """Test that URL introspection raises NotImplementedError."""
+        with pytest.raises(NotImplementedError):
+            introspect_openapi("https://example.com/openapi.json")
+
+
+class TestEndpointDefinition:
+    """Tests for EndpointDefinition model."""
+
+    def test_to_dict(self) -> None:
+        """Test converting endpoint to dictionary."""
+        spec_path = (
+            Path(__file__).parent.parent / "fixtures" / "openapi" / "sample_api.yaml"
+        )
+        analysis = introspect_openapi(str(spec_path))
+        endpoint = analysis.endpoints[0]
+
+        data = endpoint.to_dict()
+        assert "path" in data
+        assert "method" in data
+        assert "summary" in data
+        assert "description" in data
+        assert "parameters" in data
+        assert "request_body" in data
+        assert "responses" in data
+
+
+class TestOpenAPIAnalysis:
+    """Tests for OpenAPIAnalysis model."""
+
+    def test_to_dict(self) -> None:
+        """Test converting analysis to dictionary."""
+        spec_path = (
+            Path(__file__).parent.parent / "fixtures" / "openapi" / "sample_api.yaml"
+        )
+        analysis = introspect_openapi(str(spec_path))
+
+        data = analysis.to_dict()
+        assert "api_name" in data
+        assert "base_url" in data
+        assert "endpoints" in data
+        assert "schemas" in data
+        assert "authentication" in data
+        assert "capabilities" in data
+        assert isinstance(data["endpoints"], list)
+        assert len(data["endpoints"]) == 4

--- a/tests/unit/test_sources_readme.py
+++ b/tests/unit/test_sources_readme.py
@@ -1,0 +1,429 @@
+"""Tests for README parser."""
+
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from cognitive_toolworks.sources.readme import ReadmeParser, parse_readme
+
+
+class TestReadmeParser:
+    """Tests for ReadmeParser class."""
+
+    def test_basic_parsing(self) -> None:
+        """Test basic README parsing."""
+        content = """# Test Project
+
+This is a test project description.
+
+## Installation
+
+```bash
+pip install test-project
+```
+
+## Usage
+
+```python
+import test_project
+test_project.run()
+```
+
+## Features
+
+- Feature 1
+- Feature 2
+- Feature 3
+"""
+        parser = ReadmeParser(content)
+        result = parser.parse()
+
+        assert result.project_name == "Test Project"
+        assert "test project description" in result.description
+        assert result.installation is not None
+        assert "pip install test-project" in result.installation
+        assert len(result.usage_examples) > 0
+        assert len(result.features) == 3
+        assert "Feature 1" in result.features
+
+    def test_extract_sections(self) -> None:
+        """Test section extraction."""
+        content = """# Main Title
+
+Content here.
+
+## Section 1
+
+Section 1 content.
+
+## Section 2
+
+Section 2 content.
+"""
+        parser = ReadmeParser(content)
+        sections = parser._extract_sections()
+
+        assert "Main Title" in sections
+        assert "Section 1" in sections
+        assert "Section 2" in sections
+        assert "Section 1 content" in sections["Section 1"]
+
+    def test_extract_badges(self) -> None:
+        """Test badge extraction."""
+        content = """# Project
+
+[![CI](https://img.shields.io/badge/ci-passing-green)](https://ci.example.com)
+[![Version](https://img.shields.io/badge/version-1.0.0-blue)](https://example.com)
+
+Description here.
+"""
+        parser = ReadmeParser(content)
+        badges = parser._extract_badges()
+
+        assert len(badges) >= 2
+        assert any(b["alt"] == "CI" for b in badges)
+        assert any("img.shields.io" in b.get("image_url", "") for b in badges)
+
+    def test_extract_code_blocks(self) -> None:
+        """Test code block extraction."""
+        content = """# Project
+
+Install:
+
+```bash
+npm install project
+```
+
+Usage:
+
+```javascript
+const project = require('project');
+project.run();
+```
+"""
+        parser = ReadmeParser(content)
+        code_blocks = parser._extract_code_blocks()
+
+        assert len(code_blocks) == 2
+        assert code_blocks[0]["language"] == "bash"
+        assert "npm install" in code_blocks[0]["content"]
+        assert code_blocks[1]["language"] == "javascript"
+        assert "require" in code_blocks[1]["content"]
+
+    def test_extract_usage_examples(self) -> None:
+        """Test usage examples extraction."""
+        content = """# Project
+
+## Usage
+
+Basic usage:
+
+```python
+import mylib
+mylib.hello()
+```
+
+Advanced usage:
+
+```python
+import mylib
+mylib.advanced_feature()
+```
+"""
+        parser = ReadmeParser(content)
+        sections = parser._extract_sections()
+        examples = parser._extract_usage_examples(sections)
+
+        assert len(examples) == 2
+        assert all(ex["language"] == "python" for ex in examples)
+        assert "import mylib" in examples[0]["code"]
+
+    def test_extract_features(self) -> None:
+        """Test feature list extraction."""
+        content = """# Project
+
+## Features
+
+- Fast performance
+- Easy to use
+- Well documented
+- Extensible architecture
+"""
+        parser = ReadmeParser(content)
+        sections = parser._extract_sections()
+        features = parser._extract_features(sections)
+
+        assert len(features) == 4
+        assert "Fast performance" in features
+        assert "Easy to use" in features
+
+    def test_extract_dependencies_pip(self) -> None:
+        """Test dependency extraction from pip install."""
+        content = """## Installation
+
+```bash
+pip install requests numpy pandas
+```
+"""
+        parser = ReadmeParser(content)
+        deps = parser._extract_dependencies(content)
+
+        assert "requests" in deps
+        assert "numpy" in deps
+        assert "pandas" in deps
+
+    def test_extract_dependencies_npm(self) -> None:
+        """Test dependency extraction from npm install."""
+        content = """## Installation
+
+```bash
+npm install express lodash axios
+```
+"""
+        parser = ReadmeParser(content)
+        deps = parser._extract_dependencies(content)
+
+        assert "express" in deps
+        assert "lodash" in deps
+        assert "axios" in deps
+
+    def test_extract_dependencies_with_flags(self) -> None:
+        """Test dependency extraction ignores flags."""
+        content = """## Setup
+
+```bash
+pip install --upgrade requests
+npm install -D jest
+```
+"""
+        parser = ReadmeParser(content)
+        deps = parser._extract_dependencies(content)
+
+        assert "requests" in deps
+        assert "jest" in deps
+        # Flags should not be included
+        assert "--upgrade" not in deps
+        assert "-D" not in deps
+
+    def test_extract_project_name(self) -> None:
+        """Test project name extraction."""
+        content = """# My Awesome Project
+
+Description here.
+"""
+        parser = ReadmeParser(content)
+        sections = parser._extract_sections()
+        name = parser._extract_project_name(sections)
+
+        assert name == "My Awesome Project"
+
+    def test_extract_description(self) -> None:
+        """Test description extraction."""
+        content = """# Project
+
+This is the project description.
+It spans multiple lines.
+
+## Installation
+
+Install instructions.
+"""
+        parser = ReadmeParser(content)
+        sections = parser._extract_sections()
+        description = parser._extract_description(sections)
+
+        assert "project description" in description.lower()
+
+    def test_real_world_readme_pattern_1(self) -> None:
+        """Test parsing a real-world README pattern (Python project)."""
+        content = """# cognitive-toolworks
+
+[![CI](https://github.com/user/repo/workflows/CI/badge.svg)](https://github.com/user/repo)
+[![Version](https://img.shields.io/badge/version-2.0.0-blue)](https://pypi.org/project/cognitive-toolworks/)
+
+Generate AI agent skills from various sources.
+
+## Features
+
+- Parse MCP servers
+- Parse OpenAPI specs
+- Parse README files
+- Generate SKILL.md files
+
+## Installation
+
+```bash
+pip install cognitive-toolworks
+```
+
+## Usage
+
+```python
+from cognitive_toolworks import ReadmeParser
+
+parser = ReadmeParser(content)
+result = parser.parse()
+```
+
+## API Reference
+
+See the full API documentation at [docs](https://example.com/docs).
+"""
+        parser = ReadmeParser(content)
+        result = parser.parse()
+
+        assert result.project_name == "cognitive-toolworks"
+        assert "AI agent skills" in result.description
+        assert result.installation is not None
+        assert "pip install" in result.installation
+        assert len(result.features) == 4
+        assert "Parse MCP servers" in result.features
+        assert len(result.usage_examples) > 0
+        assert result.usage_examples[0]["language"] == "python"
+        assert len(result.badges) >= 2
+        assert result.api_reference is not None
+        assert len(result.dependencies) > 0
+
+    def test_real_world_readme_pattern_2(self) -> None:
+        """Test parsing a real-world README pattern (Node.js project)."""
+        content = """# express-api
+
+A lightweight Express.js API framework.
+
+## Quick Start
+
+```bash
+npm install express-api
+```
+
+## Example
+
+Create an API in seconds:
+
+```javascript
+const api = require('express-api');
+
+api.get('/hello', (req, res) => {
+  res.json({ message: 'Hello World' });
+});
+
+api.start(3000);
+```
+
+## Features
+
+* Automatic routing
+* Built-in validation
+* TypeScript support
+"""
+        parser = ReadmeParser(content)
+        result = parser.parse()
+
+        assert result.project_name == "express-api"
+        assert "Express.js API" in result.description
+        assert result.installation is not None
+        assert "npm install" in result.installation
+        assert len(result.features) == 3
+        assert "Automatic routing" in result.features
+        assert len(result.usage_examples) > 0
+
+    def test_parse_readme_function(self) -> None:
+        """Test convenience parse_readme function."""
+        content = """# Test
+
+Test description.
+
+## Install
+
+```bash
+pip install test
+```
+"""
+        with NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(content)
+            temp_path = Path(f.name)
+
+        try:
+            result = parse_readme(temp_path)
+            assert result.project_name == "Test"
+            assert result.description == "Test description."
+        finally:
+            temp_path.unlink()
+
+    def test_empty_sections(self) -> None:
+        """Test handling of README with minimal content."""
+        content = """# Minimal Project
+
+Just a title.
+"""
+        parser = ReadmeParser(content)
+        result = parser.parse()
+
+        assert result.project_name == "Minimal Project"
+        assert result.description == "Just a title."
+        assert result.installation is None
+        assert len(result.usage_examples) == 0
+        assert len(result.features) == 0
+
+    def test_nested_headers(self) -> None:
+        """Test handling of nested header levels."""
+        content = """# Main
+
+## Section 1
+
+Content 1.
+
+### Subsection 1.1
+
+Sub-content.
+
+## Section 2
+
+Content 2.
+"""
+        parser = ReadmeParser(content)
+        sections = parser._extract_sections()
+
+        assert "Section 1" in sections
+        assert "Section 2" in sections
+        # Subsections should be included in parent section
+        assert "Subsection 1.1" in sections["Section 1"]
+
+    def test_multiple_code_blocks_same_section(self) -> None:
+        """Test multiple code blocks in the same section."""
+        content = """# Project
+
+## Examples
+
+First example:
+
+```python
+print("Hello")
+```
+
+Second example:
+
+```python
+print("World")
+```
+"""
+        parser = ReadmeParser(content)
+        code_blocks = parser._extract_code_blocks()
+
+        assert len(code_blocks) == 2
+        assert all(cb["language"] == "python" for cb in code_blocks)
+
+    def test_code_block_without_language(self) -> None:
+        """Test code blocks without language specification."""
+        content = """# Project
+
+```
+generic code
+without language
+```
+"""
+        parser = ReadmeParser(content)
+        code_blocks = parser._extract_code_blocks()
+
+        assert len(code_blocks) == 1
+        assert code_blocks[0]["language"] == "text"
+        assert "generic code" in code_blocks[0]["content"]

--- a/tests/unit/test_sources_scripts.py
+++ b/tests/unit/test_sources_scripts.py
@@ -1,0 +1,406 @@
+"""Tests for script analysis module."""
+
+import tempfile
+from pathlib import Path
+
+from cognitive_toolworks.sources.scripts import (
+    ScriptAnalyzer,
+    ScriptLanguage,
+    analyze_script,
+)
+
+
+class TestScriptLanguage:
+    """Tests for ScriptLanguage enum."""
+
+    def test_from_extension_python(self) -> None:
+        """Test Python extension detection."""
+        assert ScriptLanguage.from_extension(".py") == ScriptLanguage.PYTHON
+
+    def test_from_extension_typescript(self) -> None:
+        """Test TypeScript extension detection."""
+        assert ScriptLanguage.from_extension(".ts") == ScriptLanguage.TYPESCRIPT
+        assert ScriptLanguage.from_extension(".tsx") == ScriptLanguage.TYPESCRIPT
+
+    def test_from_extension_javascript(self) -> None:
+        """Test JavaScript extension detection."""
+        assert ScriptLanguage.from_extension(".js") == ScriptLanguage.JAVASCRIPT
+        assert ScriptLanguage.from_extension(".jsx") == ScriptLanguage.JAVASCRIPT
+        assert ScriptLanguage.from_extension(".mjs") == ScriptLanguage.JAVASCRIPT
+
+    def test_from_extension_bash(self) -> None:
+        """Test Bash extension detection."""
+        assert ScriptLanguage.from_extension(".sh") == ScriptLanguage.BASH
+        assert ScriptLanguage.from_extension(".bash") == ScriptLanguage.BASH
+
+    def test_from_extension_unknown(self) -> None:
+        """Test unknown extension."""
+        assert ScriptLanguage.from_extension(".xyz") == ScriptLanguage.UNKNOWN
+
+
+class TestPythonAnalysis:
+    """Tests for Python script analysis."""
+
+    def test_analyze_simple_function(self) -> None:
+        """Test analyzing a simple Python function."""
+        content = '''"""Module docstring."""
+
+def hello(name: str) -> str:
+    """Say hello to someone."""
+    return f"Hello, {name}!"
+'''
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = analyze_script(path)
+            assert result.language == ScriptLanguage.PYTHON
+            assert "Module docstring" in result.description
+            assert len(result.functions) == 1
+            assert result.functions[0].name == "hello"
+            assert result.functions[0].return_type == "str"
+            assert len(result.functions[0].parameters) == 1
+            assert result.functions[0].parameters[0]["name"] == "name"
+        finally:
+            path.unlink()
+
+    def test_analyze_async_function(self) -> None:
+        """Test analyzing an async function."""
+        content = '''
+async def fetch_data(url: str) -> dict:
+    """Fetch data from URL."""
+    pass
+'''
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = analyze_script(path)
+            assert len(result.functions) == 1
+            assert result.functions[0].name == "fetch_data"
+            assert result.functions[0].is_async is True
+        finally:
+            path.unlink()
+
+    def test_analyze_class(self) -> None:
+        """Test analyzing a Python class."""
+        content = '''
+class MyClass:
+    """A test class."""
+
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    def get_value(self) -> int:
+        """Get the value."""
+        return self.value
+'''
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = analyze_script(path)
+            assert len(result.classes) == 1
+            assert result.classes[0].name == "MyClass"
+            assert "A test class" in result.classes[0].description
+            assert len(result.classes[0].methods) == 2  # __init__ and get_value
+        finally:
+            path.unlink()
+
+    def test_analyze_imports(self) -> None:
+        """Test extracting imports."""
+        content = """
+import os
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+from anthropic import Anthropic
+"""
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = analyze_script(path)
+            assert "os" in result.imports
+            assert "json" in result.imports
+            assert "pathlib" in result.imports
+            assert "httpx" in result.imports
+            assert "anthropic" in result.imports
+            # Check dependencies (non-stdlib)
+            assert "httpx" in result.dependencies
+            assert "anthropic" in result.dependencies
+            assert "os" not in result.dependencies
+        finally:
+            path.unlink()
+
+    def test_analyze_env_vars(self) -> None:
+        """Test extracting environment variables."""
+        content = """
+import os
+
+API_KEY = os.environ.get("ANTHROPIC_API_KEY")
+SECRET = os.getenv("SECRET_TOKEN", "default")
+"""
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = analyze_script(path)
+            assert "ANTHROPIC_API_KEY" in result.env_vars
+            assert "SECRET_TOKEN" in result.env_vars
+        finally:
+            path.unlink()
+
+    def test_analyze_typer_cli(self) -> None:
+        """Test detecting Typer CLI commands."""
+        content = """
+import typer
+
+app = typer.Typer()
+
+@app.command("hello")
+def hello_cmd():
+    pass
+
+@app.command()
+def goodbye():
+    pass
+"""
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = analyze_script(path)
+            assert len(result.cli_commands) >= 1
+            assert any(cmd["framework"] == "typer" for cmd in result.cli_commands)
+        finally:
+            path.unlink()
+
+
+class TestJavaScriptAnalysis:
+    """Tests for JavaScript/TypeScript analysis."""
+
+    def test_analyze_js_function(self) -> None:
+        """Test analyzing JavaScript functions."""
+        content = """
+export function hello(name) {
+    return `Hello, ${name}!`;
+}
+
+export const greet = async (name) => {
+    return `Hi, ${name}!`;
+};
+"""
+        with tempfile.NamedTemporaryFile(suffix=".js", mode="w", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = analyze_script(path)
+            assert result.language == ScriptLanguage.JAVASCRIPT
+            assert len(result.functions) >= 1
+            # Check for exported functions
+            assert any(f.name == "hello" for f in result.functions)
+        finally:
+            path.unlink()
+
+    def test_analyze_ts_class(self) -> None:
+        """Test analyzing TypeScript class."""
+        content = """
+export class MyService extends BaseService {
+    async getData() {
+        return [];
+    }
+}
+"""
+        with tempfile.NamedTemporaryFile(suffix=".ts", mode="w", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = analyze_script(path)
+            assert result.language == ScriptLanguage.TYPESCRIPT
+            assert len(result.classes) == 1
+            assert result.classes[0].name == "MyService"
+            assert "BaseService" in result.classes[0].base_classes
+        finally:
+            path.unlink()
+
+    def test_analyze_js_imports(self) -> None:
+        """Test extracting JavaScript imports."""
+        content = """
+import { something } from 'some-package';
+import path from 'path';
+const fs = require('fs');
+"""
+        with tempfile.NamedTemporaryFile(suffix=".js", mode="w", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = analyze_script(path)
+            assert "some-package" in result.imports
+            assert "path" in result.imports
+            assert "fs" in result.imports
+        finally:
+            path.unlink()
+
+    def test_analyze_js_env_vars(self) -> None:
+        """Test extracting JavaScript environment variables."""
+        content = """
+const apiKey = process.env.API_KEY;
+const secret = process.env['SECRET_TOKEN'];
+"""
+        with tempfile.NamedTemporaryFile(suffix=".js", mode="w", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = analyze_script(path)
+            assert "API_KEY" in result.env_vars
+            assert "SECRET_TOKEN" in result.env_vars
+        finally:
+            path.unlink()
+
+
+class TestBashAnalysis:
+    """Tests for Bash script analysis."""
+
+    def test_analyze_bash_functions(self) -> None:
+        """Test analyzing Bash functions."""
+        content = """#!/bin/bash
+# This is a test script
+# for doing things
+
+function hello() {
+    echo "Hello"
+}
+
+goodbye() {
+    echo "Goodbye"
+}
+"""
+        with tempfile.NamedTemporaryFile(suffix=".sh", mode="w", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = analyze_script(path)
+            assert result.language == ScriptLanguage.BASH
+            assert "test script" in result.description
+            assert len(result.functions) == 2
+            assert any(f.name == "hello" for f in result.functions)
+            assert any(f.name == "goodbye" for f in result.functions)
+        finally:
+            path.unlink()
+
+    def test_analyze_bash_env_vars(self) -> None:
+        """Test extracting Bash environment variables."""
+        content = """#!/bin/bash
+echo $ANTHROPIC_API_KEY
+echo ${DATABASE_URL}
+"""
+        with tempfile.NamedTemporaryFile(suffix=".sh", mode="w", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = analyze_script(path)
+            assert "ANTHROPIC_API_KEY" in result.env_vars
+            assert "DATABASE_URL" in result.env_vars
+        finally:
+            path.unlink()
+
+    def test_analyze_bash_cli_commands(self) -> None:
+        """Test extracting Bash CLI subcommands."""
+        content = """#!/bin/bash
+case "$1" in
+    start)
+        do_start
+        ;;
+    stop)
+        do_stop
+        ;;
+    restart)
+        do_restart
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart}"
+        ;;
+esac
+"""
+        with tempfile.NamedTemporaryFile(suffix=".sh", mode="w", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = analyze_script(path)
+            assert len(result.cli_commands) == 3
+            cmd_names = [cmd["name"] for cmd in result.cli_commands]
+            assert "start" in cmd_names
+            assert "stop" in cmd_names
+            assert "restart" in cmd_names
+        finally:
+            path.unlink()
+
+
+class TestScriptAnalyzer:
+    """Tests for ScriptAnalyzer class."""
+
+    def test_analyzer_to_dict(self) -> None:
+        """Test converting analysis to dictionary."""
+        content = '''"""Test module."""
+
+def test_func():
+    pass
+'''
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            analyzer = ScriptAnalyzer()
+            result = analyzer.analyze(path)
+            data = result.to_dict()
+
+            assert "file_path" in data
+            assert "language" in data
+            assert "functions" in data
+            assert data["language"] == "python"
+        finally:
+            path.unlink()
+
+    def test_unknown_extension(self) -> None:
+        """Test handling unknown file extension."""
+        with tempfile.NamedTemporaryFile(suffix=".xyz", mode="w", delete=False) as f:
+            f.write("some content")
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = analyze_script(path)
+            assert result.language == ScriptLanguage.UNKNOWN
+        finally:
+            path.unlink()

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -1,0 +1,332 @@
+"""Tests for template rendering and platform selection."""
+
+from cognitive_toolworks.generators.skill import GenerationConfig, SkillGenerator
+from cognitive_toolworks.models import Platform, SkillContent, SkillMetadata
+
+
+class TestSkillMetadataYAML:
+    """Tests for SkillMetadata YAML generation."""
+
+    def test_to_yaml_basic(self) -> None:
+        """Test basic Anthropic YAML generation."""
+        meta = SkillMetadata(
+            name="test-skill",
+            description="A test skill",
+        )
+        yaml = meta.to_yaml()
+
+        assert "---" in yaml
+        assert "name: test-skill" in yaml
+        assert 'description: "A test skill"' in yaml
+        assert yaml.count("---") == 2
+
+    def test_to_yaml_with_tools(self) -> None:
+        """Test YAML generation with allowed tools."""
+        meta = SkillMetadata(
+            name="test-skill",
+            description="A test skill",
+            allowed_tools=["Bash", "Read", "Write"],
+        )
+        yaml = meta.to_yaml()
+
+        assert "allowed-tools: Bash, Read, Write" in yaml
+
+    def test_to_yaml_with_dependencies(self) -> None:
+        """Test YAML generation with dependencies."""
+        meta = SkillMetadata(
+            name="test-skill",
+            description="A test skill",
+            dependencies=["other-skill", "another-skill"],
+        )
+        yaml = meta.to_yaml()
+
+        assert "dependencies:" in yaml
+        assert "  - other-skill" in yaml
+        assert "  - another-skill" in yaml
+
+    def test_to_openai_yaml_basic(self) -> None:
+        """Test basic OpenAI YAML generation."""
+        meta = SkillMetadata(
+            name="test-skill",
+            description="A test skill for OpenAI",
+        )
+        yaml = meta.to_openai_yaml()
+
+        assert "---" in yaml
+        assert "name: test-skill" in yaml
+        assert 'description: "A test skill for OpenAI"' in yaml
+
+    def test_to_openai_yaml_with_category(self) -> None:
+        """Test OpenAI YAML includes category field."""
+        meta = SkillMetadata(
+            name="test-skill",
+            description="A test skill",
+            category="automation",
+        )
+        yaml = meta.to_openai_yaml()
+
+        assert "category: automation" in yaml
+
+    def test_to_openai_yaml_with_version(self) -> None:
+        """Test OpenAI YAML includes version field."""
+        meta = SkillMetadata(
+            name="test-skill",
+            description="A test skill",
+            version="2.1.0",
+        )
+        yaml = meta.to_openai_yaml()
+
+        assert "version: 2.1.0" in yaml
+
+    def test_to_openai_yaml_longer_description(self) -> None:
+        """Test OpenAI YAML supports longer descriptions."""
+        # 500 chars - too long for Anthropic, OK for OpenAI
+        long_desc = "a" * 500
+        meta = SkillMetadata(
+            name="test-skill",
+            description=long_desc,
+        )
+
+        # Should validate fine for OpenAI
+        issues = meta.validate_openai()
+        assert len(issues) == 0
+
+        # Should render without issues
+        yaml = meta.to_openai_yaml()
+        assert long_desc in yaml
+
+
+class TestSkillGeneratorTemplateSelection:
+    """Tests for platform-based template selection in SkillGenerator."""
+
+    def test_default_platform_universal(self) -> None:
+        """Test default platform is UNIVERSAL."""
+        config = GenerationConfig()
+        assert config.platform == Platform.UNIVERSAL
+
+    def test_render_skill_anthropic(self) -> None:
+        """Test rendering with Anthropic template."""
+        config = GenerationConfig(platform=Platform.ANTHROPIC)
+        generator = SkillGenerator(config=config)
+
+        meta = SkillMetadata(
+            name="test-skill",
+            description="Test skill for Anthropic",
+        )
+        skill = SkillContent(
+            metadata=meta,
+            overview="This is a test skill",
+            when_to_use=["When you need to test", "When testing is required"],
+            quick_reference="Run the test",
+            instructions="Execute the test command",
+            examples=[
+                {
+                    "title": "Basic Test",
+                    "description": "Run a basic test",
+                    "code": "test --run",
+                    "language": "bash",
+                }
+            ],
+            guidelines=["Follow best practices", "Test thoroughly"],
+        )
+
+        rendered = generator.render_skill(skill, platform=Platform.ANTHROPIC)
+
+        # Check frontmatter
+        assert "---" in rendered
+        assert "name: test-skill" in rendered
+        assert "# Test Skill" in rendered
+
+        # Check sections
+        assert "## When to Use This Skill" in rendered
+        assert "- When you need to test" in rendered
+        assert "## Quick Reference" in rendered
+        assert "## Instructions" in rendered
+        assert "## Examples" in rendered
+        assert "### Example 1: Basic Test" in rendered
+        assert "## Guidelines" in rendered
+        assert "```bash" in rendered
+
+    def test_render_skill_openai(self) -> None:
+        """Test rendering with OpenAI template."""
+        config = GenerationConfig(platform=Platform.OPENAI)
+        generator = SkillGenerator(config=config)
+
+        meta = SkillMetadata(
+            name="openai-test-skill",
+            description="Test skill for OpenAI Codex CLI",
+            category="testing",
+            version="1.2.0",
+        )
+        skill = SkillContent(
+            metadata=meta,
+            overview="This is an OpenAI test skill",
+            when_to_use=["When using Codex CLI"],
+            quick_reference="codex test",
+            instructions="Run codex test command",
+            examples=[],
+            guidelines=["Use best practices"],
+        )
+
+        rendered = generator.render_skill(skill, platform=Platform.OPENAI)
+
+        # Check OpenAI-specific frontmatter
+        assert "name: openai-test-skill" in rendered
+        assert "category: testing" in rendered
+        assert "version: 1.2.0" in rendered
+
+        # Check structure
+        assert "# Openai Test Skill" in rendered
+        assert "## When to Use This Skill" in rendered
+
+    def test_render_skill_universal_uses_anthropic(self) -> None:
+        """Test UNIVERSAL platform uses Anthropic template (more restrictive)."""
+        config = GenerationConfig(platform=Platform.UNIVERSAL)
+        generator = SkillGenerator(config=config)
+
+        meta = SkillMetadata(
+            name="universal-skill",
+            description="Universal skill",
+        )
+        skill = SkillContent(
+            metadata=meta,
+            overview="Universal skill overview",
+            when_to_use=["Always"],
+            quick_reference="run",
+            instructions="Execute",
+            examples=[],
+            guidelines=[],
+        )
+
+        # UNIVERSAL should use Anthropic template as it's more restrictive
+        rendered = generator.render_skill(skill, platform=Platform.UNIVERSAL)
+
+        # Should look like Anthropic format
+        assert "name: universal-skill" in rendered
+        assert "# Universal Skill" in rendered
+
+    def test_render_skill_with_troubleshooting(self) -> None:
+        """Test rendering with troubleshooting section."""
+        config = GenerationConfig(platform=Platform.ANTHROPIC)
+        generator = SkillGenerator(config=config)
+
+        meta = SkillMetadata(name="test-skill", description="Test")
+        skill = SkillContent(
+            metadata=meta,
+            overview="Test",
+            when_to_use=["Test"],
+            quick_reference="test",
+            instructions="Test",
+            examples=[],
+            guidelines=[],
+            troubleshooting=[
+                {"issue": "Command fails", "solution": "Check permissions"},
+                {"issue": "Timeout error", "solution": "Increase timeout value"},
+            ],
+        )
+
+        rendered = generator.render_skill(skill)
+
+        assert "## Troubleshooting" in rendered
+        assert "### Command fails" in rendered
+        assert "Check permissions" in rendered
+        assert "### Timeout error" in rendered
+
+    def test_render_skill_with_references(self) -> None:
+        """Test rendering with references section."""
+        config = GenerationConfig(platform=Platform.OPENAI)
+        generator = SkillGenerator(config=config)
+
+        meta = SkillMetadata(name="test-skill", description="Test")
+        skill = SkillContent(
+            metadata=meta,
+            overview="Test",
+            when_to_use=["Test"],
+            quick_reference="test",
+            instructions="Test",
+            examples=[],
+            guidelines=[],
+            references=[
+                "[Official Docs](https://example.com/docs)",
+                "[GitHub](https://github.com/example)",
+            ],
+        )
+
+        rendered = generator.render_skill(skill)
+
+        assert "## See Also" in rendered
+        assert "[Official Docs](https://example.com/docs)" in rendered
+        assert "[GitHub](https://github.com/example)" in rendered
+
+    def test_platform_override(self) -> None:
+        """Test platform override in render_skill."""
+        # Generator configured for ANTHROPIC
+        config = GenerationConfig(platform=Platform.ANTHROPIC)
+        generator = SkillGenerator(config=config)
+
+        meta = SkillMetadata(
+            name="test-skill",
+            description="Test",
+            category="test",
+        )
+        skill = SkillContent(
+            metadata=meta,
+            overview="Test",
+            when_to_use=["Test"],
+            quick_reference="test",
+            instructions="Test",
+            examples=[],
+            guidelines=[],
+        )
+
+        # Override to use OpenAI template
+        rendered = generator.render_skill(skill, platform=Platform.OPENAI)
+
+        # Should use OpenAI format (includes category)
+        assert "category: test" in rendered
+
+
+class TestPlatformValidation:
+    """Tests for platform-specific validation."""
+
+    def test_anthropic_description_limit(self) -> None:
+        """Test Anthropic enforces 200 char description limit."""
+        meta = SkillMetadata(
+            name="test-skill",
+            description="a" * 250,  # Too long
+        )
+        issues = meta.validate_anthropic()
+        assert len(issues) > 0
+        assert any("200 chars" in issue for issue in issues)
+
+    def test_openai_description_limit(self) -> None:
+        """Test OpenAI allows 1024 char descriptions."""
+        meta = SkillMetadata(
+            name="test-skill",
+            description="a" * 500,  # OK for OpenAI
+        )
+        issues = meta.validate_openai()
+        assert len(issues) == 0
+
+    def test_openai_description_too_long(self) -> None:
+        """Test OpenAI enforces 1024 char limit."""
+        meta = SkillMetadata(
+            name="test-skill",
+            description="a" * 1100,  # Too long
+        )
+        issues = meta.validate_openai()
+        assert len(issues) > 0
+        assert any("1024 chars" in issue for issue in issues)
+
+    def test_universal_should_use_stricter_limits(self) -> None:
+        """Test that UNIVERSAL platform should use Anthropic's stricter limits."""
+        # This is a design choice - UNIVERSAL should be compatible with both,
+        # so it should use the more restrictive limits (Anthropic's 200 chars)
+        meta = SkillMetadata(
+            name="test-skill",
+            description="a" * 250,
+        )
+
+        # For UNIVERSAL, validate against Anthropic limits
+        anthropic_issues = meta.validate_anthropic()
+        assert len(anthropic_issues) > 0


### PR DESCRIPTION
## Summary

- **OpenAPI spec parser** (#26): Full introspection of OpenAPI 3.0/3.1 specs with endpoint, schema, and auth extraction
- **README/documentation parser** (#27): Extracts sections, badges, code blocks, dependencies from markdown READMEs
- **Script analyzer** (#28): Analyzes Python, TypeScript/JavaScript, and Bash scripts for functions, classes, imports, env vars
- **OpenAI skill template** (#40): New template for OpenAI Codex CLI format (1024 char limit vs Anthropic's 200)

## Test plan

- [x] All 138 unit tests pass
- [x] 83 new tests added for new parsers and templates
- [x] Pre-commit hooks pass (black, ruff, mypy)

Closes #26, closes #27, closes #28, closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)