### PR TITLE
docs: remove vestigial content and fix inaccurate claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,8 +221,6 @@ ct validate ./skill/ --verbose                       # Detailed validation
 CT_DEBUG=1 ct generate skill ...                     # Enable debug logging
 ct introspect mcp ./config.json --raw               # Raw introspection output
 
-# Benchmarking
-ct benchmark ./skills/ --iterations 10              # Performance testing
 ```
 
 ## Architecture Notes
@@ -243,4 +241,3 @@ Source → Introspector → Analyzer → Generator → Validator → Optimizer �
 ### Claude-Flow Integration
 - Workflows in `.claude-flow/workflows/`
 - Agent definitions in `.claude-flow/agents/`
-- Use `--orchestrated` flag to enable multi-agent mode

--- a/docs/COVERAGE_MATRIX.md
+++ b/docs/COVERAGE_MATRIX.md
@@ -1,7 +1,7 @@
 # Skill Coverage Matrix Analysis
 
 **Total Skills**: 81
-**Analysis Date**: $(date -I)
+**Analysis Date**: 2025-12-15
 
 ## Coverage by Tier
 
@@ -180,41 +180,38 @@
 
 ## Gap Analysis
 
-### Identified Coverage Gaps
+### Current Coverage
 
 **Cloud Providers:**
 - ✅ AWS: `cloud-aws-architect` (comprehensive)
-- ⚠️ Azure: No dedicated architect skill
-- ⚠️ GCP: No dedicated architect skill
+- ✅ Azure: `cloud-azure-architect`
+- ✅ GCP: `cloud-gcp-architect`
 
 **Language-Specific Tooling:**
-- ✅ Existing: rust
-- ⚠️ Missing: Java, TypeScript/JavaScript, C#, C++
+- ✅ Rust: `rust-analyzer`
+- ✅ Java: `tooling-java-generator`
+- ✅ TypeScript: `tooling-typescript-generator`
+- ✅ C#: `tooling-csharp-generator`
+- ✅ Python: `tooling-python-generator`
 
 **Testing:**
 - ✅ Core testing skills: 5
-- ⚠️ Missing: Performance profiling, mutation testing, visual regression
+- ⚠️ Gaps: Performance profiling, mutation testing, visual regression
 
 **Observability:**
-- ✅ Observability skills: 3
-- ⚠️ Missing: APM-specific (Datadog, New Relic), cost attribution
+- ✅ Observability skills: 4
+- ⚠️ Gaps: APM-specific (Datadog, New Relic), cost attribution
 
 ### Recommendations
 
-**High Priority:**
-1. Add Azure/GCP cloud architect skills (parity with AWS)
-2. Add Java and TypeScript tooling specialists
-3. Create testing orchestrator agent (coordinates test strategy execution)
-
 **Medium Priority:**
-4. Performance profiling skill (language-agnostic)
-5. APM integration skill (Datadog, New Relic, etc.)
-6. Visual regression testing skill
+1. Performance profiling skill (language-agnostic)
+2. APM integration skill (Datadog, New Relic, etc.)
+3. Visual regression testing skill
 
 **Low Priority:**
-7. C#/.NET tooling specialist
-8. C++ build system specialist (CMake, Bazel)
-9. Mutation testing designer
+4. C++ build system specialist (CMake, Bazel)
+5. Mutation testing designer
 
 ## Domain Coverage Heat Map
 

--- a/docs/EXPANSION_ROADMAP.md
+++ b/docs/EXPANSION_ROADMAP.md
@@ -1,17 +1,20 @@
 # Cognitive Toolworks Expansion Roadmap
 
-**Status**: Active Development
-**Last Updated**: 2025-10-26
+**Status**: Historical Reference (superseded by actual implementation)
+**Last Updated**: 2025-12-15
+**Original Created**: 2025-10-26
 **Vision**: Comprehensive language support + End-to-end design studio capabilities
+
+> **Note**: This roadmap was written when the project had 65 skills. Many items listed as "to be created" have since been implemented. See COVERAGE_MATRIX.md for current state.
 
 ---
 
-## Current State (Baseline)
+## Current State (Actual)
 
-**Skills**: 65
+**Skills**: 81
 **Agents**: 18
-**Language Coverage**: Python (comprehensive), Go (scaffolding), Rust (analysis)
-**Design Coverage**: API design, architecture decisions, microservices patterns
+**Language Coverage**: Python, Go, Rust, Java, TypeScript, C#
+**Design Coverage**: API design, architecture decisions, microservices patterns, cloud architecture
 
 ---
 
@@ -21,37 +24,17 @@
 
 **Goal**: Add comprehensive tooling for top 5 languages by usage
 
-#### 1.1 Java Ecosystem (`tooling-java-generator`)
+#### 1.1 Java Ecosystem (`tooling-java-generator`) — ✅ IMPLEMENTED
+- **Status**: Complete (skill exists in skills/)
 - **Scope**: Maven/Gradle, JUnit 5, Spring Boot, Lombok
-- **Deliverables**:
-  - Project scaffolding (library, application, microservice)
-  - Testing framework setup (JUnit 5, Mockito, TestContainers)
-  - Build configuration (Maven, Gradle, multi-module)
-  - Packaging (JAR, WAR, Docker, native-image)
-- **Skill Type**: Tier 3 Specialized
-- **Token Budget**: T1 ≤2k, T2 ≤6k, T3 ≤12k
-- **Priority**: **P0** (mentioned in user todos)
 
-#### 1.2 TypeScript/JavaScript Ecosystem (`tooling-typescript-generator`)
+#### 1.2 TypeScript/JavaScript Ecosystem (`tooling-typescript-generator`) — ✅ IMPLEMENTED
+- **Status**: Complete (skill exists in skills/)
 - **Scope**: Node.js, TypeScript, Jest, ESLint, Prettier
-- **Deliverables**:
-  - Project types: library, CLI, API, frontend (React/Vue)
-  - TypeScript configuration (strict, paths, decorators)
-  - Testing: Jest, Vitest, Playwright
-  - Bundling: Vite, Rollup, esbuild
-  - Linting: ESLint, Prettier, tsconfig validation
-- **Skill Type**: Tier 3 Specialized
-- **Priority**: **P0** (mentioned in user todos)
 
-#### 1.3 C# / .NET Ecosystem (`tooling-csharp-generator`)
+#### 1.3 C# / .NET Ecosystem (`tooling-csharp-generator`) — ✅ IMPLEMENTED
+- **Status**: Complete (skill exists in skills/)
 - **Scope**: .NET 8+, xUnit, MSTest, NuGet
-- **Deliverables**:
-  - Project types: class library, console app, ASP.NET Core, Blazor
-  - Testing: xUnit, NUnit, MSTest, Moq
-  - Packaging: NuGet, dotnet pack
-  - Configuration: csproj, solution files
-- **Skill Type**: Tier 3 Specialized
-- **Priority**: **P1**
 
 ### Tier 2 - Mobile & Native Languages
 
@@ -109,31 +92,17 @@
 
 ---
 
-## Phase 2: Cloud Architecture Parity
+## Phase 2: Cloud Architecture Parity — ✅ COMPLETE
 
 ### Goal: Achieve feature parity across AWS, Azure, GCP
 
-#### 2.1 Azure Cloud Architect Agent (`cloud-azure-orchestrator`)
+#### 2.1 Azure Cloud Architect Agent (`cloud-azure-orchestrator`) — ✅ IMPLEMENTED
+- **Status**: Complete (agent exists in agents/)
 - **Scope**: Azure multi-service orchestration
-- **Capabilities**:
-  - Compute: VMs, App Service, AKS, Functions
-  - Storage: Blob, Cosmos DB, SQL Database
-  - Networking: VNet, Application Gateway, Front Door
-  - Security: Key Vault, Entra ID, Sentinel
-- **Skills Integration**: azure-architect (new), cloud-multicloud-advisor, security-cloud-analyzer
-- **Agent Type**: Orchestrator (4-step workflow)
-- **Priority**: **P0**
 
-#### 2.2 GCP Cloud Architect Agent (`cloud-gcp-orchestrator`)
+#### 2.2 GCP Cloud Architect Agent (`cloud-gcp-orchestrator`) — ✅ IMPLEMENTED
+- **Status**: Complete (agent exists in agents/)
 - **Scope**: GCP multi-service orchestration
-- **Capabilities**:
-  - Compute: Compute Engine, GKE, Cloud Functions, Cloud Run
-  - Storage: Cloud Storage, Firestore, Cloud SQL, BigQuery
-  - Networking: VPC, Cloud CDN, Cloud Load Balancing
-  - Security: Secret Manager, IAM, Security Command Center
-- **Skills Integration**: gcp-architect (new), cloud-multicloud-advisor, security-cloud-analyzer
-- **Agent Type**: Orchestrator
-- **Priority**: **P0**
 
 ---
 
@@ -410,23 +379,22 @@ Every new skill/agent must:
 
 ---
 
-## Next Steps (Immediate)
+## Completed Items (as of 2025-12-15)
 
-1. **Start with P0 items**:
-   - Create `tooling-java-generator` skill
-   - Create `tooling-typescript-generator` skill
-   - Create `cloud-azure-orchestrator` agent
-   - Create `cloud-gcp-orchestrator` agent
-   - Create `testing-orchestrator` agent
+The following roadmap items have been implemented:
 
-2. **Update embeddings** after each batch
+- ✅ `tooling-java-generator` skill
+- ✅ `tooling-typescript-generator` skill
+- ✅ `tooling-csharp-generator` skill
+- ✅ `cloud-azure-orchestrator` agent
+- ✅ `cloud-gcp-orchestrator` agent
 
-3. **Rebuild coverage matrix** to track progress
+## Remaining Work
 
-4. **Iterate based on usage patterns** and feedback
+For current gaps and recommendations, see COVERAGE_MATRIX.md.
 
 ---
 
 **Maintained by**: cognitive-toolworks
-**CLAUDE.md Version**: 1.4.0
-**Roadmap Status**: Active Development
+**CLAUDE.md Version**: 1.7.0
+**Roadmap Status**: Historical Reference


### PR DESCRIPTION
## Summary

- Remove references to removed features (`ct benchmark`, `--orchestrated` flag)
- Fix unfilled shell variable `$(date -I)` in COVERAGE_MATRIX.md
- Fix false claims about "missing" skills that actually exist
- Mark EXPANSION_ROADMAP.md as historical reference (created when 65 skills existed, now 81)

## Changes

**AGENTS.md:**
- Removed `ct benchmark` command example (benchmarking was removed)
- Removed `--orchestrated` flag reference (feature was removed)

**COVERAGE_MATRIX.md:**
- Fixed `$(date -I)` → `2025-12-15`
- Fixed gap analysis: Azure/GCP/Java/TypeScript/C# skills exist, not missing

**EXPANSION_ROADMAP.md:**
- Marked as "Historical Reference" (superseded by implementation)
- Updated skill count: 65 → 81
- Marked implemented items: Java, TypeScript, C#, Azure, GCP orchestrators

## Motivation

Documentation should accurately reflect what exists. Claims that X is "missing" when X exists in skills/ are misleading. Removed features should not be documented as working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)