### PR TITLE
fix(ci): resolve black/ruff version-drift breaking Code Quality job

### DIFF
--- a/src/cognitive_toolworks/analyzers/coverage.py
+++ b/src/cognitive_toolworks/analyzers/coverage.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import ClassVar
 
 
-class CoverageLevel(str, Enum):
+class CoverageLevel(StrEnum):
     """Coverage completeness levels."""
 
     COMPLETE = "complete"

--- a/src/cognitive_toolworks/analyzers/security.py
+++ b/src/cognitive_toolworks/analyzers/security.py
@@ -13,14 +13,14 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-class Severity(str, Enum):
+class Severity(StrEnum):
     """Security issue severity levels."""
 
     CRITICAL = "critical"
@@ -30,7 +30,7 @@ class Severity(str, Enum):
     INFO = "info"
 
 
-class IssueType(str, Enum):
+class IssueType(StrEnum):
     """Types of security issues."""
 
     FILE_SYSTEM = "file_system"

--- a/src/cognitive_toolworks/cli.py
+++ b/src/cognitive_toolworks/cli.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import Annotated
 
@@ -29,7 +29,7 @@ app = typer.Typer(
 console = Console()
 
 
-class Platform(str, Enum):
+class Platform(StrEnum):
     """Target platform for skill generation."""
 
     ANTHROPIC = "anthropic"
@@ -37,7 +37,7 @@ class Platform(str, Enum):
     UNIVERSAL = "universal"
 
 
-class SourceType(str, Enum):
+class SourceType(StrEnum):
     """Type of source to generate from."""
 
     MCP = "mcp"

--- a/src/cognitive_toolworks/generators/examples.py
+++ b/src/cognitive_toolworks/generators/examples.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from cognitive_toolworks.llm.client import LLMClient
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from cognitive_toolworks.models import SemanticAnalysis, SkillContent
 
 
-class ExampleComplexity(str, Enum):
+class ExampleComplexity(StrEnum):
     """Complexity level for generated examples."""
 
     SIMPLE = "simple"

--- a/src/cognitive_toolworks/llm/client.py
+++ b/src/cognitive_toolworks/llm/client.py
@@ -11,13 +11,13 @@ import asyncio
 import json
 import os
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 import httpx
 
 
-class LLMProvider(str, Enum):
+class LLMProvider(StrEnum):
     """Supported LLM providers."""
 
     ANTHROPIC = "anthropic"

--- a/src/cognitive_toolworks/models.py
+++ b/src/cognitive_toolworks/models.py
@@ -7,11 +7,11 @@ These models define the structure of skills, analysis reports, and configuration
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 
-class Platform(str, Enum):
+class Platform(StrEnum):
     """Target platform for skill generation."""
 
     ANTHROPIC = "anthropic"
@@ -22,7 +22,7 @@ class Platform(str, Enum):
         return self.value
 
 
-class SourceType(str, Enum):
+class SourceType(StrEnum):
     """Type of source to generate from."""
 
     MCP_SERVER = "mcp"
@@ -526,7 +526,7 @@ class ReadmeAnalysis:
         }
 
 
-class CompatibilitySeverity(str, Enum):
+class CompatibilitySeverity(StrEnum):
     """Severity of compatibility issues."""
 
     ERROR = "error"  # Blocks platform compatibility

--- a/src/cognitive_toolworks/sources/scripts.py
+++ b/src/cognitive_toolworks/sources/scripts.py
@@ -11,14 +11,14 @@ import ast
 import contextlib
 import re
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-class ScriptLanguage(str, Enum):
+class ScriptLanguage(StrEnum):
     """Supported script languages."""
 
     PYTHON = "python"

--- a/src/cognitive_toolworks/validators/anthropic.py
+++ b/src/cognitive_toolworks/validators/anthropic.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, ClassVar
 
 import yaml
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-class ValidationSeverity(str, Enum):
+class ValidationSeverity(StrEnum):
     """Severity of validation issues."""
 
     ERROR = "error"  # Blocks compliance

--- a/tests/test_build_agents_index.py
+++ b/tests/test_build_agents_index.py
@@ -33,8 +33,7 @@ class TestFrontMatterExtraction:
 
     def test_valid_front_matter(self) -> None:
         """Extract valid front matter successfully."""
-        md = dedent(
-            """\
+        md = dedent("""\
             ---
             name: Test Agent
             slug: test-agent
@@ -44,8 +43,7 @@ class TestFrontMatterExtraction:
             tools: [Read, Write, Bash]
             ---
             # Body content
-            """
-        )
+            """)
         meta = extract_front_matter(md)
         assert meta["name"] == "Test Agent"
         assert meta["slug"] == "test-agent"

--- a/tests/test_build_index.py
+++ b/tests/test_build_index.py
@@ -33,8 +33,7 @@ class TestFrontMatterExtraction:
 
     def test_valid_front_matter(self) -> None:
         """Extract valid front matter successfully."""
-        md = dedent(
-            """\
+        md = dedent("""\
             ---
             name: Test Skill
             slug: test-skill
@@ -42,8 +41,7 @@ class TestFrontMatterExtraction:
             keywords: [test, skill]
             ---
             # Body content
-            """
-        )
+            """)
         meta = extract_front_matter(md)
         assert meta["name"] == "Test Skill"
         assert meta["slug"] == "test-skill"

--- a/tests/test_lint_skill.py
+++ b/tests/test_lint_skill.py
@@ -48,16 +48,14 @@ class TestExtractBody:
 
     def test_extract_with_front_matter(self) -> None:
         """Extract body when front matter present."""
-        md = dedent(
-            """\
+        md = dedent("""\
             ---
             name: Test
             slug: test
             ---
             ## Purpose & When-To-Use
             Body content
-            """
-        )
+            """)
         body = extract_body(md)
         assert "## Purpose & When-To-Use" in body
         assert "Body content" in body
@@ -86,8 +84,7 @@ class TestCheckHeadingOrder:
 
     def test_correct_order(self, tmp_path: Path) -> None:
         """Accept headings in correct order."""
-        body = dedent(
-            """\
+        body = dedent("""\
             ## Purpose & When-To-Use
             Purpose
 
@@ -111,8 +108,7 @@ class TestCheckHeadingOrder:
 
             ## Resources
             Resources
-            """
-        )
+            """)
         issues = check_heading_order(body, tmp_path / "test.md")
         # Should only have no order errors (missing sections checked elsewhere)
         order_errors = [i for i in issues if "out of order" in i.message]
@@ -120,15 +116,13 @@ class TestCheckHeadingOrder:
 
     def test_wrong_order(self, tmp_path: Path) -> None:
         """Detect headings out of order."""
-        body = dedent(
-            """\
+        body = dedent("""\
             ## Procedure
             Procedure
 
             ## Purpose & When-To-Use
             Purpose (should come before Procedure)
-            """
-        )
+            """)
         issues = check_heading_order(body, tmp_path / "test.md")
         order_issues = [i for i in issues if "out of order" in i.message]
         assert len(order_issues) > 0
@@ -144,8 +138,7 @@ class TestCheckHeadingOrder:
 
     def test_extra_headings_ignored(self, tmp_path: Path) -> None:
         """Ignore extra headings not in required list."""
-        body = dedent(
-            """\
+        body = dedent("""\
             ## Purpose & When-To-Use
             Purpose
 
@@ -154,8 +147,7 @@ class TestCheckHeadingOrder:
 
             ## Pre-Checks
             Checks
-            """
-        )
+            """)
         issues = check_heading_order(body, tmp_path / "test.md")
         # Custom Section should be ignored (not cause errors)
         order_errors = [i for i in issues if "Custom Section" in i.message]
@@ -174,8 +166,7 @@ class TestCheckCodeFences:
 
     def test_properly_closed_fences(self, tmp_path: Path) -> None:
         """Accept properly closed code fences."""
-        body = dedent(
-            """\
+        body = dedent("""\
             Some text
             ```python
             code
@@ -184,20 +175,17 @@ class TestCheckCodeFences:
             ```
             another block
             ```
-            """
-        )
+            """)
         issues = check_code_fences(body, tmp_path / "test.md")
         assert len(issues) == 0
 
     def test_unclosed_fence(self, tmp_path: Path) -> None:
         """Detect unclosed code fence."""
-        body = dedent(
-            """\
+        body = dedent("""\
             Text
             ```python
             code without closing
-            """
-        )
+            """)
         issues = check_code_fences(body, tmp_path / "test.md")
         assert len(issues) == 1
         assert "Unclosed code fence" in issues[0].message
@@ -211,8 +199,7 @@ class TestCheckCodeFences:
 
     def test_multiple_unclosed(self, tmp_path: Path) -> None:
         """Detect last unclosed fence in odd number."""
-        body = dedent(
-            """\
+        body = dedent("""\
             ```
             block1
             ```
@@ -221,8 +208,7 @@ class TestCheckCodeFences:
             ```
             ```
             unclosed block3
-            """
-        )
+            """)
         issues = check_code_fences(body, tmp_path / "test.md")
         assert len(issues) == 1
         assert "line 7" in issues[0].message
@@ -390,8 +376,7 @@ class TestLintSkillFile:
         """Lint valid SKILL.md file."""
         skill_file = tmp_path / "SKILL.md"
         skill_file.write_text(
-            dedent(
-                """\
+            dedent("""\
                 ---
                 name: Test
                 slug: test
@@ -422,8 +407,7 @@ class TestLintSkillFile:
 
                 ## Resources
                 Resources
-                """
-            ),
+                """),
             encoding="utf-8",
         )
         issues = lint_skill_file(skill_file, validate_links=False)
@@ -441,8 +425,7 @@ class TestLintSkillFile:
         """Detect multiple types of issues."""
         skill_file = tmp_path / "SKILL.md"
         skill_file.write_text(
-            dedent(
-                """\
+            dedent("""\
                 ---
                 name: Test
                 ---
@@ -452,8 +435,7 @@ class TestLintSkillFile:
 
                 ```
                 Unclosed fence
-                """
-            ),
+                """),
             encoding="utf-8",
         )
         issues = lint_skill_file(skill_file, validate_links=False)
@@ -472,8 +454,7 @@ class TestMain:
     def create_skill_file(self, path: Path, valid: bool = True) -> Path:
         """Helper to create a test SKILL.md file."""
         if valid:
-            content = dedent(
-                """\
+            content = dedent("""\
                 ---
                 name: Test
                 slug: test
@@ -504,11 +485,9 @@ class TestMain:
 
                 ## Resources
                 Resources
-                """
-            )
+                """)
         else:
-            content = dedent(
-                """\
+            content = dedent("""\
                 ---
                 name: Test
                 ---
@@ -518,8 +497,7 @@ class TestMain:
 
                 ```
                 Unclosed fence
-                """
-            )
+                """)
 
         skill_file = path / "SKILL.md"
         skill_file.write_text(content, encoding="utf-8")
@@ -572,16 +550,14 @@ class TestMain:
         # Create skill with missing sections (warnings) but no errors
         skill_file = skills_dir / "SKILL.md"
         skill_file.write_text(
-            dedent(
-                """\
+            dedent("""\
                 ---
                 name: Test
                 ---
 
                 ## Purpose & When-To-Use
                 Only one section (will trigger warnings for missing sections)
-                """
-            ),
+                """),
             encoding="utf-8",
         )
 
@@ -599,8 +575,7 @@ class TestMain:
 
         skill_file = skills_dir / "SKILL.md"
         skill_file.write_text(
-            dedent(
-                """\
+            dedent("""\
                 ---
                 name: Test
                 ---
@@ -632,8 +607,7 @@ class TestMain:
 
                 ## Resources
                 Resources
-                """
-            ),
+                """),
             encoding="utf-8",
         )
 

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -31,16 +31,14 @@ class TestFrontMatterExtraction:
 
     def test_valid_front_matter(self) -> None:
         """Extract valid front matter successfully."""
-        md = dedent(
-            """\
+        md = dedent("""\
             ---
             name: Test Skill
             slug: test-skill
             version: 1.0.0
             ---
             # Content here
-            """
-        )
+            """)
         fm = extract_front_matter(md)
         assert isinstance(fm, FrontMatter)
         assert fm.meta["name"] == "Test Skill"
@@ -84,23 +82,20 @@ class TestCodeBlockDetection:
 
     def test_single_code_block(self) -> None:
         """Detect single code block."""
-        text = dedent(
-            """\
+        text = dedent("""\
             Some text
             ```python
             print("hello")
             ```
             More text
-            """
-        )
+            """)
         blocks = find_code_blocks(text)
         assert len(blocks) == 1
         assert blocks[0] == (1, 3)  # Line indices
 
     def test_multiple_code_blocks(self) -> None:
         """Detect multiple code blocks."""
-        text = dedent(
-            """\
+        text = dedent("""\
             ```
             code1
             ```
@@ -108,8 +103,7 @@ class TestCodeBlockDetection:
             ```
             code2
             ```
-            """
-        )
+            """)
         blocks = find_code_blocks(text)
         assert len(blocks) == 2
 
@@ -131,8 +125,7 @@ class TestExampleBlockLength:
 
     def test_example_with_code_block(self) -> None:
         """Calculate length of example code block."""
-        text = dedent(
-            """\
+        text = dedent("""\
             ## Examples
 
             ```python
@@ -140,8 +133,7 @@ class TestExampleBlockLength:
             line2
             line3
             ```
-            """
-        )
+            """)
         length = first_examples_block_len(text)
         assert length == 3
 
@@ -159,8 +151,7 @@ class TestExampleBlockLength:
 
     def test_multiple_code_blocks_uses_first(self) -> None:
         """Use first code block in Examples section."""
-        text = dedent(
-            """\
+        text = dedent("""\
             ## Examples
 
             ```
@@ -171,8 +162,7 @@ class TestExampleBlockLength:
             second
             second2
             ```
-            """
-        )
+            """)
         length = first_examples_block_len(text)
         assert length == 1  # First block has 1 line
 
@@ -255,8 +245,7 @@ class TestSkillFileValidation:
         """Validate minimal valid SKILL.md file."""
         skill = tmp_path / "SKILL.md"
         skill.write_text(
-            dedent(
-                """\
+            dedent("""\
                 ---
                 name: Test Skill
                 slug: test-skill
@@ -300,8 +289,7 @@ class TestSkillFileValidation:
                 ```python
                 print("example")
                 ```
-                """
-            ),
+                """),
             encoding="utf-8",
         )
         issues = validate_skill_file(skill)
@@ -311,15 +299,13 @@ class TestSkillFileValidation:
         """Detect missing required metadata keys."""
         skill = tmp_path / "SKILL.md"
         skill.write_text(
-            dedent(
-                """\
+            dedent("""\
                 ---
                 name: Test
                 slug: test
                 ---
                 # Content
-                """
-            ),
+                """),
             encoding="utf-8",
         )
         issues = validate_skill_file(skill)
@@ -331,8 +317,7 @@ class TestSkillFileValidation:
         long_desc = "x" * (MAX_DESCRIPTION_LEN + 1)
         skill = tmp_path / "SKILL.md"
         skill.write_text(
-            dedent(
-                f"""\
+            dedent(f"""\
                 ---
                 name: Test
                 slug: test
@@ -348,8 +333,7 @@ class TestSkillFileValidation:
                 links: []
                 ---
                 # Content
-                """
-            ),
+                """),
             encoding="utf-8",
         )
         issues = validate_skill_file(skill)
@@ -359,8 +343,7 @@ class TestSkillFileValidation:
         """Detect missing required body sections."""
         skill = tmp_path / "SKILL.md"
         skill.write_text(
-            dedent(
-                """\
+            dedent("""\
                 ---
                 name: Test
                 slug: test
@@ -378,8 +361,7 @@ class TestSkillFileValidation:
 
                 ## Purpose & When-To-Use
                 Only one section
-                """
-            ),
+                """),
             encoding="utf-8",
         )
         issues = validate_skill_file(skill)
@@ -391,8 +373,7 @@ class TestSkillFileValidation:
         """Detect missing token budgets."""
         skill = tmp_path / "SKILL.md"
         skill.write_text(
-            dedent(
-                """\
+            dedent("""\
                 ---
                 name: Test
                 slug: test
@@ -433,8 +414,7 @@ class TestSkillFileValidation:
                 ```
                 example
                 ```
-                """
-            ),
+                """),
             encoding="utf-8",
         )
         issues = validate_skill_file(skill)
@@ -546,8 +526,7 @@ small example
         """Detect secrets in skill file."""
         skill = tmp_path / "SKILL.md"
         skill.write_text(
-            dedent(
-                """\
+            dedent("""\
                 ---
                 name: Test
                 slug: test
@@ -588,8 +567,7 @@ small example
                 ```
                 example
                 ```
-                """
-            ),
+                """),
             encoding="utf-8",
         )
         issues = validate_skill_file(skill)

--- a/tests/unit/test_sources_docs.py
+++ b/tests/unit/test_sources_docs.py
@@ -604,8 +604,7 @@ advanced.process()
 
             # Create realistic doc structure
             (temp_dir / "mkdocs.yml").write_text("site_name: My Project Docs\n")
-            (temp_dir / "index.md").write_text(
-                """# My Project
+            (temp_dir / "index.md").write_text("""# My Project
 
 Welcome to My Project documentation.
 
@@ -614,13 +613,11 @@ Welcome to My Project documentation.
 ```bash
 pip install myproject
 ```
-"""
-            )
+""")
 
             guides_dir = temp_dir / "guides"
             guides_dir.mkdir()
-            (guides_dir / "installation.md").write_text(
-                """# Installation
+            (guides_dir / "installation.md").write_text("""# Installation
 
 Install via pip:
 
@@ -633,11 +630,9 @@ Or via conda:
 ```bash
 conda install myproject
 ```
-"""
-            )
+""")
 
-            (guides_dir / "usage.md").write_text(
-                """# Usage
+            (guides_dir / "usage.md").write_text("""# Usage
 
 Basic usage:
 
@@ -655,13 +650,11 @@ from myproject import advanced
 
 advanced.process(data)
 ```
-"""
-            )
+""")
 
             api_dir = temp_dir / "api"
             api_dir.mkdir()
-            (api_dir / "reference.md").write_text(
-                """# API Reference
+            (api_dir / "reference.md").write_text("""# API Reference
 
 ## Classes
 
@@ -674,8 +667,7 @@ Main class for the library.
 def process_data(data, options)
 
 Processes the input data.
-"""
-            )
+""")
 
             parser = DocsParser()
             result = parser.parse_directory(temp_dir)

--- a/tests/unit/test_validators_aaif.py
+++ b/tests/unit/test_validators_aaif.py
@@ -650,8 +650,7 @@ description: "Test"
         """Test validate_file method."""
         validator = AAIFValidator()
         skill_file = tmp_path / "SKILL.md"
-        skill_file.write_text(
-            """---
+        skill_file.write_text("""---
 name: "Test Skill"
 slug: "testing-unit-validator"
 description: "Valid description"
@@ -702,8 +701,7 @@ Gates.
 ## Resources
 
 Resources.
-"""
-        )
+""")
         result = validator.validate_file(skill_file)
         assert isinstance(result.valid, bool)
         assert isinstance(result.score, float)

--- a/tooling/lint_skill.py
+++ b/tooling/lint_skill.py
@@ -6,6 +6,7 @@ Checks:
 - Code fences are properly closed
 - External links are valid (HTTP status check)
 """
+
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Root cause

The **Code Quality** job (`quality.yaml`) fails on `main`.

The reported symptom — `No files were found with the provided path: bandit-report.json` followed by exit code 1 — is a **downstream effect**, not the cause. The job aborts at an earlier step before Bandit ever runs, so `bandit-report.json` is never written and the `upload-artifact` step finds nothing.

The actual failure: the workflow installs `black` and `ruff` with floating version specs (`black>=24.0`, `ruff>=0.7.0`). Newer releases now flag pre-existing code, and the `Format check (black)` / `Lint (ruff)` steps have **no** `continue-on-error`, so they hard-fail the job:

- **black 26.x** enforces a blank line after the module docstring — reformats 7 files.
- **ruff 0.15.x** stabilized `UP042`, flagging 12 `class X(str, Enum)` declarations that should use `enum.StrEnum` (the project targets Python 3.11).

Bandit itself is healthy: it runs, writes `bandit-report.json`, reports only LOW/MEDIUM findings, and its step is already `continue-on-error: true`. It is *not* the failure — it just never gets reached.

This is a genuine break on `main`; Dependabot PR #85 inherits it.

## Fix

1. **Apply black formatting** to the 7 affected files — purely cosmetic, no behavior change.
2. **Migrate the 12 enums to `enum.StrEnum`** (`from enum import StrEnum`, `class X(StrEnum)`).

The `StrEnum` migration is safe here:
- Serialization paths use explicit `.value` (e.g. `self.severity.value`).
- The `models.py` enums already define `__str__` returning `self.value` — identical to `StrEnum`'s default.
- Every test compares enum members by equality (`==`), which is unchanged under `StrEnum`.

## Verification (local)

- `black --check .` -> pass
- `ruff check .` -> `All checks passed!`
- `mypy tooling/` -> `Success: no issues found`
- `pytest` -> 59 passed
- `bandit -r tooling/` -> exit 0, report written, LOW/MEDIUM only (advisory)

## Unblocks

Dependabot PR #85 (`github/codeql-action` 3.35.1 -> 4.35.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)